### PR TITLE
Add generic binary animation channels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ A lightweight Three.js viewer designed to be controlled from Python/Jupyter note
 
 ### Core Files
 - `src/threejs_viewer/client.py` - Python client that runs WebSocket server
-- `src/threejs_viewer/animation.py` - Animation classes (Frame, Animation, Marker)
+- `src/threejs_viewer/animation.py` - Animation classes (Frame, Animation, AnimationChannel, Marker)
 - `src/threejs_viewer/viewer.html` - Three.js viewer (self-contained)
 - `examples/` - Demo scripts showcasing library capabilities
 
@@ -52,11 +52,21 @@ A lightweight Three.js viewer designed to be controlled from Python/Jupyter note
 - 3D models: GLTF/GLB, STL, OBJ, FBX, DAE, PLY, 3DS
 - **draw_range**: polylines and meshes support `set_draw_range(id, 0.0-1.0)` to control visible fraction, and `draw_ranges` channel in animation frames
 
-### Binary Animation Channels
-For large animations (100k+ frames), use zero-loop binary APIs instead of Frame objects:
+### Animation: Two Approaches
+**Frame-based (simple, familiar):** Build frames as Python dicts — good for small animations and prototyping.
+**Binary channels (fast):** Use `add_channel()` / convenience wrappers for large animations (100+ objects × 1000+ frames). Data is packed as typed arrays, transferred via HTTP, and applied with zero-copy TypedArray views in JS.
+
+Binary channel API:
 - `animation.set_frame_times(times)` — numpy array of frame times
 - `animation.set_transform_data(object_ids, data)` — (n_frames, n_objects, 16) float32
 - `animation.set_draw_range_data(object_ids, data)` — (n_frames, n_objects) float32
+- `animation.add_channel(name, ids, data, dtype, stride, metadata)` — generic channel
+
+Supported channel types: `transforms` (stride=16), `draw_ranges`, `colors`, `visibility`, `opacity`
+Supported dtypes: `float32`, `uint32`, `uint8`
+Indexed colors: `dtype="uint8"` + `metadata={"colormap": [0x44AA44, 0xFF3333]}`
+
+Binary channels and Frame-based JSON can coexist (e.g. binary transforms + JSON clip_times). A binary channel supersedes the same-named Frame field.
 
 ### Examples
 - `01_primitives.py` - Basic shapes with colors and positions

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -89,7 +89,10 @@ client.load_animation(animation)
 
 ### Animation System
 
-Pre-computed animations for interactive playback:
+There are two ways to build animations, designed for different use cases:
+
+**Frame-based (simple, familiar)** — build frames as Python dicts. Good for small
+animations and prototyping:
 
 ```python
 from threejs_viewer import Animation, Frame
@@ -101,10 +104,29 @@ for t in times:
         transforms={"obj1": matrix1, "obj2": matrix2},
         colors={"obj1": 0xFF0000},
         visibility={"obj2": False},
-        clip_times={"glb_model": t},  # drive embedded GLTF animations
+        clip_times={"glb_model": t},
     )
 animation.add_marker(5.0, "Collision!")
 ```
+
+**Binary channels (fast)** — for large animations (100+ objects × 1000+ frames).
+Data is packed as typed arrays and transferred via HTTP:
+
+```python
+animation = Animation(loop=True)
+animation.set_frame_times(np.arange(n_frames) / 60.0)
+animation.set_transform_data(object_ids, transforms)       # (n_frames, n_objects, 16) float32
+animation.set_draw_range_data(draw_ids, draw_ranges)        # (n_frames, n_objects) float32
+animation.add_channel("colors", ids, data, dtype="uint8",   # indexed colormap
+                       metadata={"colormap": [0x44AA44, 0xFF3333]})
+animation.add_channel("visibility", ids, data, dtype="uint8")
+```
+
+The two approaches can be mixed: binary channels supersede Frame fields with the
+same name, while Frame-only fields (like `clip_times`) are sent as sparse JSON.
+
+Supported channel types: `transforms` (stride=16), `draw_ranges`, `colors`,
+`visibility`, `opacity`. Supported dtypes: `float32`, `uint32`, `uint8`.
 
 ### Embedded GLTF Animations
 
@@ -154,6 +176,32 @@ All messages are JSON (text) or binary with JSON header.
 {"type": "stop_animation"}
 ```
 
+For binary-channel animations, the message is `load_animation_http` with a channel manifest:
+
+```json
+{
+  "type": "load_animation_http",
+  "blob_url": "http://localhost:5667/animation_XXXX",
+  "frame_count": 2000,
+  "frame_times": [0.0, 0.0167, ...],
+  "duration": 33.3,
+  "fps": 60,
+  "loop": true,
+  "markers": [],
+  "channels": [
+    {"name": "transforms",  "ids": ["obj1", ...], "dtype": "float32", "stride": 16},
+    {"name": "colors",      "ids": ["s0", ...],   "dtype": "uint8",   "stride": 1, "colormap": [4489156, 16724787]},
+    {"name": "visibility",  "ids": ["s0", ...],   "dtype": "uint8",   "stride": 1},
+    {"name": "draw_ranges", "ids": ["obj1", ...], "dtype": "float32", "stride": 1}
+  ],
+  "frames_meta": [{"index": 42, "clip_times": {"model1": 1.5}}]
+}
+```
+
+The binary blob (served via HTTP) is the concatenation of all channel data in manifest order.
+Each channel's byte size = `n_frames × len(ids) × stride × sizeof(dtype)`.
+Channels are sorted by dtype size descending (float32 first, uint8 last) to avoid alignment issues.
+
 ### Embedded GLTF Animations
 
 ```json
@@ -165,10 +213,12 @@ Animation frames can also include `clip_times` to drive embedded animations duri
 
 ### Binary Messages
 
-For `add_model_binary` and `add_polyline_binary`:
-- First 4 bytes: header length (uint32 little-endian)
-- Next N bytes: JSON header (null-padded to 4-byte boundary)
-- Remaining bytes: raw binary data
+For large data (meshes, polylines, animations), the Python client serves binary
+payloads via an HTTP sidecar on port 5667. A JSON message over WebSocket carries
+metadata and a `blob_url`; the browser fetches the binary blob with native `fetch()`.
+
+For animation channels, the blob is a concatenation of all channel typed arrays
+(see the channel manifest in the `load_animation_http` message above).
 
 ## File Structure
 
@@ -178,7 +228,7 @@ threejs-viewer/
 │   ├── __init__.py      # Package exports
 │   ├── __main__.py      # CLI entry point
 │   ├── client.py        # ViewerClient class
-│   ├── animation.py     # Animation, Frame, Marker classes
+│   ├── animation.py     # Animation, AnimationChannel, Frame, Marker classes
 │   └── viewer.html      # Browser viewer (self-contained)
 ├── pyproject.toml
 ├── DESIGN.md
@@ -228,10 +278,11 @@ print(ViewerClient().viewer_path)
 
 ## Performance Considerations
 
-- **Batch updates**: Use `set_transforms()` for multiple objects instead of individual calls
+- **Batch updates**: Use `batch_update()` for multiple objects instead of individual calls
 - **Binary transfer**: Use `add_model_binary()` and `add_polyline()` for large data
+- **Binary animation channels**: Use `add_channel()` / `set_transform_data()` for large animations — avoids JSON serialization overhead on both Python and JS sides
 - **Animation pre-computation**: Build all frames upfront, let viewer handle playback
-- **Object reuse**: Use `sync()` to avoid reloading unchanged objects
+- **Performance warnings**: Both Python (logging) and JS (console.warn) emit hints when JSON animation data is large enough that binary channels would help
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ client.load_animation(animation)
 
 Viewer controls: Space (play/pause), Arrow keys (step frames), 1-5 (speed), L (loop)
 
+### Binary Channels (Large Animations)
+
+For animations with many objects or frames, use binary channels instead of Frame dicts for much faster serialization and transfer:
+
+```python
+import numpy as np
+from threejs_viewer import Animation
+
+animation = Animation(loop=True)
+animation.set_frame_times(np.arange(n_frames) / 60.0)
+
+# Transforms: (n_frames, n_objects, 16) float32
+animation.set_transform_data(object_ids, transform_array)
+
+# Draw ranges: (n_frames, n_objects) float32
+animation.set_draw_range_data(object_ids, draw_range_array)
+
+# Colors with indexed colormap: (n_frames, n_objects) uint8
+animation.add_channel("colors", object_ids, color_indices, dtype="uint8",
+                       metadata={"colormap": [0x44AA44, 0xFF3333]})
+
+# Visibility: (n_frames, n_objects) uint8 (0=hidden, 1=visible)
+animation.add_channel("visibility", object_ids, vis_data, dtype="uint8")
+
+client.load_animation(animation)
+```
+
+Binary channels and Frame-based JSON can be mixed (e.g. binary transforms + JSON `clip_times`).
+
 ### GLB Models with Embedded Animations
 
 ```python

--- a/examples/05_lissajous_curves.py
+++ b/examples/05_lissajous_curves.py
@@ -2,7 +2,11 @@
 Lissajous Curves Explorer
 
 Visualizes beautiful 3D Lissajous curves with animated parameters.
-A sphere traces the curve in real-time while the full path is shown.
+A sphere traces the curve in real-time with a fading ghost trail.
+
+Demonstrates binary animation channels:
+- transforms: position for tracer + trail spheres (float32, stride 16)
+- opacity: trail fades from fully opaque to invisible (float32)
 
 Run: uv run python examples/05_lissajous_curves.py
 """
@@ -14,34 +18,12 @@ import numpy as np
 from threejs_viewer import Animation, viewer
 
 
-def make_transform_matrix(position, scale=1.0):
-    """Create a simple translation matrix."""
-    return [
-        scale,
-        0,
-        0,
-        0,
-        0,
-        scale,
-        0,
-        0,
-        0,
-        0,
-        scale,
-        0,
-        position[0],
-        position[1],
-        position[2],
-        1,
-    ]
-
-
 def lissajous_3d(t, a, b, c, delta_x=0, delta_y=0, scale=3):
-    """Compute 3D Lissajous curve point."""
-    x = scale * math.sin(a * t + delta_x)
-    y = scale * math.sin(b * t + delta_y)
-    z = scale * math.sin(c * t) + scale + 0.5  # Offset above ground
-    return x, y, z
+    """Compute 3D Lissajous curve points (vectorized)."""
+    x = scale * np.sin(a * t + delta_x)
+    y = scale * np.sin(b * t + delta_y)
+    z = scale * np.sin(c * t) + scale + 0.5
+    return np.column_stack([x, y, z])
 
 
 v = viewer()
@@ -53,20 +35,16 @@ v.add_box(
 )
 
 # Curve parameters (interesting ratios create beautiful patterns)
-A, B, C = 3, 4, 5  # Frequency ratios
+A, B, C = 3, 4, 5
 DELTA_X = math.pi / 2
 DELTA_Y = 0
 SCALE = 3
 
 # Generate the full curve for static display
 n_curve_points = 2000
-curve_points = np.zeros((n_curve_points, 3))
-t_values = np.linspace(0, 2 * math.pi, n_curve_points)
+t_curve = np.linspace(0, 2 * math.pi, n_curve_points)
+curve_points = lissajous_3d(t_curve, A, B, C, DELTA_X, DELTA_Y, SCALE)
 
-for i, t in enumerate(t_values):
-    curve_points[i] = lissajous_3d(t, A, B, C, DELTA_X, DELTA_Y, SCALE)
-
-# Add the curve with gradient coloring
 v.add_polyline(
     "lissajous_curve",
     curve_points,
@@ -75,42 +53,55 @@ v.add_polyline(
     line_width=2,
 )
 
-# Add a tracer sphere
-v.add_sphere("tracer", radius=0.15, color=0xFF4444)
-
-# Add a "ghost" trail of smaller spheres
+# Add tracer + trail spheres (all same size — opacity does the fading)
 N_TRAIL = 8
+v.add_sphere("tracer", radius=0.15, color=0xFF4444)
 for i in range(N_TRAIL):
-    alpha = 1.0 - (i / N_TRAIL)  # Fade out
-    v.add_sphere(f"trail_{i}", radius=0.08 * alpha, color=0xFF8888)
+    v.add_sphere(f"trail_{i}", radius=0.12, color=0xFF8888)
 
-# Create animation - sphere traces the curve
+# Pre-compute animation with binary channels
 duration = 10.0
-fps = 60  # Smooth tracing
+fps = 60
 n_frames = int(duration * fps)
+n_objects = 1 + N_TRAIL  # tracer + trail spheres
+object_ids = ["tracer"] + [f"trail_{i}" for i in range(N_TRAIL)]
 
+# Compute all curve parameter values for tracer and each trail offset
+trail_offsets = np.array([0.0] + [(i + 1) * 0.05 for i in range(N_TRAIL)])
+frame_times = np.arange(n_frames) / fps
+t_params = (frame_times / duration) * 2 * math.pi  # (n_frames,)
+
+# (n_frames, n_objects) curve parameter for each object at each frame
+t_all = t_params[:, None] - trail_offsets[None, :]  # broadcast
+
+# Vectorized position computation for all objects and frames at once
+positions = lissajous_3d(t_all.ravel(), A, B, C, DELTA_X, DELTA_Y, SCALE).reshape(
+    n_frames, n_objects, 3
+)
+
+# Build transform matrices: identity with translation
+all_transforms = np.zeros((n_frames, n_objects, 16), dtype=np.float32)
+all_transforms[:, :, 0] = 1.0  # scale x
+all_transforms[:, :, 5] = 1.0  # scale y
+all_transforms[:, :, 10] = 1.0  # scale z
+all_transforms[:, :, 15] = 1.0  # w
+all_transforms[:, :, 12] = positions[:, :, 0]  # tx
+all_transforms[:, :, 13] = positions[:, :, 1]  # ty
+all_transforms[:, :, 14] = positions[:, :, 2]  # tz
+
+# Opacity: tracer=1.0, trail fades linearly to 0
+trail_opacity = np.linspace(
+    1.0, 0.0, N_TRAIL + 1, endpoint=False
+)  # [1.0, 0.875, ..., 0.125]
+# Same opacity every frame — broadcast to (n_frames, n_objects)
+all_opacity = np.broadcast_to(trail_opacity, (n_frames, n_objects)).astype(np.float32)
+
+# Build animation
 animation = Animation(loop=True)
+animation.set_frame_times(frame_times)
+animation.set_transform_data(object_ids, all_transforms)
+animation.add_channel("opacity", object_ids, all_opacity, dtype="float32")
 
-for frame_idx in range(n_frames):
-    t_anim = frame_idx / fps
-    t_param = (t_anim / duration) * 2 * math.pi  # Map to curve parameter
-
-    transforms = {}
-
-    # Main tracer position
-    pos = lissajous_3d(t_param, A, B, C, DELTA_X, DELTA_Y, SCALE)
-    transforms["tracer"] = make_transform_matrix(pos)
-
-    # Trail positions (previous positions)
-    for i in range(N_TRAIL):
-        trail_offset = (i + 1) * 0.05  # Time offset for each trail sphere
-        t_trail = t_param - trail_offset
-        trail_pos = lissajous_3d(t_trail, A, B, C, DELTA_X, DELTA_Y, SCALE)
-        transforms[f"trail_{i}"] = make_transform_matrix(trail_pos)
-
-    animation.add_frame(time=t_anim, transforms=transforms)
-
-# Markers at interesting points
 animation.add_marker(0.0, "Start", color=0x00FF00)
 animation.add_marker(duration / 4, "1/4 cycle", color=0x0088FF)
 animation.add_marker(duration / 2, "1/2 cycle", color=0xFFFF00)

--- a/examples/10_animation_stress_test.py
+++ b/examples/10_animation_stress_test.py
@@ -3,12 +3,15 @@ Animation Stress Test
 
 Same torus knot tube and followers as 07_stress_test.py, but pre-computed
 as an Animation with timeline scrubbing. Tests how the viewer handles
-large animation payloads (500+ objects x 600 frames).
+large animation payloads (500+ objects x 2500 frames).
+
+Demonstrates binary animation channels:
+- transforms: position/rotation for all followers (float32, stride 16)
+- colors: dynamic color based on Z-height via indexed colormap (uint8)
 
 Run: uv run python examples/10_animation_stress_test.py
 """
 
-import colorsys
 import random
 import time
 from pathlib import Path
@@ -145,37 +148,35 @@ PRIMITIVES = ["sphere", "box", "cylinder", "capsule", "cone"]
 
 followers = []
 for i in range(NUM_FOLLOWERS):
-    hue = random.uniform(0, 1)
-    r, g, b = colorsys.hsv_to_rgb(hue, 0.9, 0.9)
-    color = (int(r * 255) << 16) | (int(g * 255) << 8) | int(b * 255)
     size = random.uniform(0.1, 0.3)
 
     fid = f"f{i}"
     ptype = PRIMITIVES[i % len(PRIMITIVES)]
 
+    # Start grey — the binary color channel will override each frame
     if ptype == "sphere":
-        v.add_sphere(fid, radius=size, color=color)
+        v.add_sphere(fid, radius=size, color=0x888888)
     elif ptype == "box":
-        v.add_box(fid, width=size, height=size, depth=size * 2, color=color)
+        v.add_box(fid, width=size, height=size, depth=size * 2, color=0x888888)
     elif ptype == "cylinder":
         v.add_cylinder(
             fid,
             radius_top=size * 0.4,
             radius_bottom=size * 0.4,
             height=size * 2,
-            color=color,
+            color=0x888888,
         )
     elif ptype == "capsule":
-        v.add_capsule(fid, radius=size * 0.4, length=size, color=color)
+        v.add_capsule(fid, radius=size * 0.4, length=size, color=0x888888)
     elif ptype == "cone":
         v.add_cylinder(
-            fid, radius_top=0, radius_bottom=size * 0.5, height=size * 2, color=color
+            fid, radius_top=0, radius_bottom=size * 0.5, height=size * 2, color=0x888888
         )
 
     followers.append(
         {
             "id": fid,
-            "speed": random.uniform(5, 30),
+            "speed": random.expovariate(1 / 10) + 1,
             "offset": random.randint(0, NUM_POINTS - 1),
         }
     )
@@ -188,7 +189,7 @@ for i in range(NUM_TEAPOTS):
     followers.append(
         {
             "id": fid,
-            "speed": random.uniform(5, 20),
+            "speed": random.expovariate(1 / 8) + 1,
             "offset": random.randint(0, NUM_POINTS - 1),
             "scale": 0.2,
         }
@@ -208,6 +209,36 @@ f_scales = np.array([f.get("scale", 1.0) for f in followers])
 
 # Pre-allocate the full transform array: (n_frames, n_followers, 16)
 all_transforms = np.zeros((n_frames, n_followers, 16), dtype=np.float32)
+# Color index per follower per frame (uint8, indexes into a colormap)
+all_colors = np.zeros((n_frames, n_followers), dtype=np.uint8)
+
+# Ranges for normalizing position to colormap / scale
+z_min, z_max = points[:, 2].min(), points[:, 2].max()
+x_min, x_max = points[:, 0].min(), points[:, 0].max()
+
+# Build a smooth 256-entry colormap by linearly interpolating key stops
+COLOR_STOPS = np.array(
+    [
+        [0x33, 0x66, 0xCC],  # deep blue (bottom)
+        [0x33, 0xAA, 0xCC],  # teal
+        [0x33, 0xCC, 0x66],  # green
+        [0xAA, 0xCC, 0x33],  # lime
+        [0xFF, 0xCC, 0x00],  # yellow
+        [0xFF, 0x88, 0x00],  # orange
+        [0xFF, 0x33, 0x33],  # red (top)
+    ],
+    dtype=np.float32,
+)
+n_stops = len(COLOR_STOPS)
+t_palette = np.linspace(0, 1, 256)
+t_stops = np.linspace(0, 1, n_stops)
+# Interpolate each RGB component
+palette_rgb = np.column_stack(
+    [np.interp(t_palette, t_stops, COLOR_STOPS[:, c]) for c in range(3)]
+).astype(np.uint8)
+COLOR_PALETTE = [(int(r) << 16) | (int(g) << 8) | int(b) for r, g, b in palette_rgb]
+N_COLORS = 256
+
 frame_indices = np.arange(n_frames)
 
 for frame_idx in frame_indices:
@@ -219,28 +250,42 @@ for frame_idx in frame_indices:
     tan_all = points[indices_next] - pos_all  # (N, 3)
     quats = quaternions_from_directions(tan_all)  # (N, 4)
 
+    # Dynamic scale: 0.5x to 2x based on X position
+    x_norm = (pos_all[:, 0] - x_min) / (x_max - x_min + 1e-8)
+    scale = f_scales * (0.5 + 1.5 * x_norm)
+
     # Vectorized quaternion -> rotation matrix, written directly into array
     qx, qy, qz, qw = quats[:, 0], quats[:, 1], quats[:, 2], quats[:, 3]
     m = all_transforms[frame_idx]
-    m[:, 0] = f_scales * (1 - 2 * (qy * qy + qz * qz))
-    m[:, 1] = f_scales * (2 * (qx * qy + qz * qw))
-    m[:, 2] = f_scales * (2 * (qx * qz - qy * qw))
-    m[:, 4] = f_scales * (2 * (qx * qy - qz * qw))
-    m[:, 5] = f_scales * (1 - 2 * (qx * qx + qz * qz))
-    m[:, 6] = f_scales * (2 * (qy * qz + qx * qw))
-    m[:, 8] = f_scales * (2 * (qx * qz + qy * qw))
-    m[:, 9] = f_scales * (2 * (qy * qz - qx * qw))
-    m[:, 10] = f_scales * (1 - 2 * (qx * qx + qy * qy))
+    m[:, 0] = scale * (1 - 2 * (qy * qy + qz * qz))
+    m[:, 1] = scale * (2 * (qx * qy + qz * qw))
+    m[:, 2] = scale * (2 * (qx * qz - qy * qw))
+    m[:, 4] = scale * (2 * (qx * qy - qz * qw))
+    m[:, 5] = scale * (1 - 2 * (qx * qx + qz * qz))
+    m[:, 6] = scale * (2 * (qy * qz + qx * qw))
+    m[:, 8] = scale * (2 * (qx * qz + qy * qw))
+    m[:, 9] = scale * (2 * (qy * qz - qx * qw))
+    m[:, 10] = scale * (1 - 2 * (qx * qx + qy * qy))
     m[:, 12] = pos_all[:, 0]
     m[:, 13] = pos_all[:, 1]
     m[:, 14] = pos_all[:, 2]
     m[:, 15] = 1.0
 
-# Build animation with pre-built binary data (skips dict-to-numpy in load_animation)
+    # Color index from Z-height: normalize to 0..255
+    z_norm = (pos_all[:, 2] - z_min) / (z_max - z_min + 1e-8)
+    all_colors[frame_idx] = (np.clip(z_norm, 0, 1) * 255).astype(np.uint8)
+
+# Build animation with binary channels (no Frame objects needed)
 animation = Animation(loop=True)
-for frame_idx in range(n_frames):
-    animation.add_frame(time=frame_idx / FPS, transforms={})
+animation.set_frame_times(np.arange(n_frames) / FPS)
 animation.set_transform_data(f_ids, all_transforms)
+animation.add_channel(
+    "colors",
+    f_ids,
+    all_colors,
+    dtype="uint8",
+    metadata={"colormap": COLOR_PALETTE},
+)
 
 compute_time = time.time() - start
 print(f"Computed in {compute_time:.1f}s")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.2"
+version = "0.0.3"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -6,13 +6,14 @@ Three.js viewer connects to. Designed for robotics visualization,
 scientific computing, and interactive 3D exploration.
 """
 
-from .animation import Animation, Frame, Marker
+from .animation import Animation, AnimationChannel, Frame, Marker
 from .client import ViewerClient, viewer
 
 __all__ = [
     "ViewerClient",
     "viewer",
     "Animation",
+    "AnimationChannel",
     "Frame",
     "Marker",
 ]

--- a/src/threejs_viewer/animation.py
+++ b/src/threejs_viewer/animation.py
@@ -5,8 +5,12 @@ Allows pre-computing entire simulations and sending them to the viewer
 for interactive playback with timeline scrubbing, speed control, and frame stepping.
 """
 
+import logging
 from dataclasses import dataclass, field
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -16,6 +20,18 @@ class Marker:
     time: float
     label: str
     color: int = 0xFF0000
+
+
+@dataclass
+class AnimationChannel:
+    """A named binary data channel for animation."""
+
+    name: str
+    ids: list[str]
+    data: np.ndarray  # (n_frames, n_ids * stride)
+    dtype: str  # "float32", "uint32", "uint8"
+    stride: int  # elements per object per frame (16 for transforms, 1 for scalars)
+    metadata: dict | None  # e.g. {"colormap": [0x44AA44, 0xFF3333]}
 
 
 @dataclass
@@ -63,13 +79,11 @@ class Animation:
     loop: bool = True
     markers: list[Marker] = field(default_factory=list)
 
-    # Optional pre-built binary data for fast transfer.
-    # Set via set_transform_data() / set_draw_range_data() / set_frame_times().
-    _transform_data: np.ndarray | None = field(default=None, repr=False)
-    _object_ids: list[str] | None = field(default=None, repr=False)
+    # Generic binary channels for fast transfer.
+    _channels: list[AnimationChannel] = field(default_factory=list, repr=False)
+
+    # Optional frame times (set via set_frame_times() for binary-only animations).
     _frame_times: np.ndarray | None = field(default=None, repr=False)
-    _draw_range_data: np.ndarray | None = field(default=None, repr=False)
-    _draw_range_ids: list[str] | None = field(default=None, repr=False)
 
     @property
     def duration(self) -> float:
@@ -119,36 +133,51 @@ class Animation:
             )
         )
 
-    def set_transform_data(self, object_ids: list[str], data: np.ndarray) -> None:
-        """
-        Set pre-built transform data for fast binary transfer.
+    def add_channel(
+        self,
+        name: str,
+        object_ids: list[str],
+        data: np.ndarray,
+        dtype: str = "float32",
+        stride: int = 1,
+        metadata: dict | None = None,
+    ) -> None:
+        """Add a binary data channel.
 
-        This bypasses the per-frame dict-to-numpy conversion in load_animation,
-        which is the main bottleneck for large animations.
+        Replaces any existing channel with the same name.
 
         Args:
-            object_ids: Ordered list of object IDs matching axis 1 of data
-            data: numpy array of shape (n_frames, n_objects, 16), dtype float32
-                  Column-major 4x4 matrices.
+            name: Channel name (e.g. "transforms", "colors", "visibility").
+            object_ids: Ordered list of object IDs matching axis 1 of data.
+            data: Array of shape (n_frames, n_objects * stride). Will be cast to dtype.
+            dtype: Element type — "float32", "uint32", or "uint8".
+            stride: Elements per object per frame (16 for 4x4 matrices, 1 for scalars).
+            metadata: Extra info sent in the header (e.g. colormap for indexed colors).
         """
-        self._object_ids = object_ids
-        self._transform_data = np.ascontiguousarray(data, dtype=np.float32)
+        # Replace existing channel with same name (prevents duplicates)
+        self._channels = [ch for ch in self._channels if ch.name != name]
+        self._channels.append(
+            AnimationChannel(
+                name=name,
+                ids=list(object_ids),
+                data=data,
+                dtype=dtype,
+                stride=stride,
+                metadata=metadata,
+            )
+        )
+
+    def set_transform_data(self, object_ids: list[str], data: np.ndarray) -> None:
+        """Convenience: add a 'transforms' channel with stride=16."""
+        self.add_channel("transforms", object_ids, data, dtype="float32", stride=16)
 
     def set_frame_times(self, times) -> None:
         """Set frame times from array, bypassing Frame object creation."""
         self._frame_times = np.asarray(times, dtype=np.float64)
 
     def set_draw_range_data(self, object_ids: list[str], data: np.ndarray) -> None:
-        """
-        Set pre-built draw_range data for fast binary transfer.
-
-        Args:
-            object_ids: Ordered list of object IDs matching axis 1 of data
-            data: numpy array of shape (n_frames, n_objects), dtype float32
-                  Values in 0.0-1.0 range.
-        """
-        self._draw_range_ids = list(object_ids)
-        self._draw_range_data = np.ascontiguousarray(data, dtype=np.float32)
+        """Convenience: add a 'draw_ranges' channel."""
+        self.add_channel("draw_ranges", object_ids, data, dtype="float32", stride=1)
 
     def add_marker(self, time: float, label: str, color: int = 0xFF0000) -> None:
         """Add a labeled marker on the timeline."""

--- a/src/threejs_viewer/animation.py
+++ b/src/threejs_viewer/animation.py
@@ -5,12 +5,11 @@ Allows pre-computing entire simulations and sending them to the viewer
 for interactive playback with timeline scrubbing, speed control, and frame stepping.
 """
 
-import logging
 from dataclasses import dataclass, field
 
 import numpy as np
 
-logger = logging.getLogger(__name__)
+ALLOWED_DTYPES = {"float32", "uint32", "uint8"}
 
 
 @dataclass
@@ -28,9 +27,9 @@ class AnimationChannel:
 
     name: str
     ids: list[str]
-    data: np.ndarray  # (n_frames, n_ids * stride)
+    data: np.ndarray  # (n_frames, n_ids, stride) or (n_frames, n_ids) for stride=1
     dtype: str  # "float32", "uint32", "uint8"
-    stride: int  # elements per object per frame (16 for transforms, 1 for scalars)
+    stride: int  # elements per object per frame (16 for 4x4 matrices, 1 for scalars)
     metadata: dict | None  # e.g. {"colormap": [0x44AA44, 0xFF3333]}
 
 
@@ -154,6 +153,10 @@ class Animation:
             stride: Elements per object per frame (16 for 4x4 matrices, 1 for scalars).
             metadata: Extra info sent in the header (e.g. colormap for indexed colors).
         """
+        if dtype not in ALLOWED_DTYPES:
+            raise ValueError(
+                f"Unsupported dtype {dtype!r}. Allowed: {sorted(ALLOWED_DTYPES)}"
+            )
         # Replace existing channel with same name (prevents duplicates)
         self._channels = [ch for ch in self._channels if ch.name != name]
         self._channels.append(

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -827,8 +827,9 @@ class ViewerClient:
         self._blob_store[blob_key] = binary_payload
         blob_url = f"http://{self.host}:{self._http_port}{blob_key}"
 
-        # Skip JSON reconvert for reconnect when binary channels are used
-        # (the JSON-based to_dict() path is exactly the bloat problem we're avoiding)
+        # Binary-channel animations skip reconnect replay — storing hundreds of MB
+        # of typed arrays for re-send isn't worthwhile; the user re-runs the script.
+        # Frame-based (JSON) animations are small enough to store and replay.
         if channels:
             self._current_animation = None
         elif animation.frames:

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -682,8 +682,9 @@ class ViewerClient:
         """
         Load an animation for playback in the viewer.
 
-        Uses binary transfer for transform data (fast) with JSON for
-        sparse channels (colors, visibility, opacity, clip_times).
+        Uses binary transfer for bulk channels (transforms, draw_ranges,
+        colors, visibility, etc.) with JSON for sparse per-frame metadata
+        (clip_times, or any channel without a binary version).
 
         Args:
             animation: Animation object with pre-computed frames
@@ -707,13 +708,12 @@ class ViewerClient:
             n_frames = len(animation.frames)
             frame_times = [f.time for f in animation.frames]
 
-        # Use pre-built binary data if available (fastest path)
-        if animation._transform_data is not None and animation._object_ids is not None:
-            all_ids = animation._object_ids
-            n_objects = len(all_ids)
-            transform_data = animation._transform_data
-        else:
-            # Build from frame dicts
+        # Collect channels — copy list so we don't mutate the Animation object
+        channels = list(animation._channels)
+        binary_channel_names = {ch.name for ch in channels}
+
+        # If frames have transforms but no binary transforms channel, build one
+        if "transforms" not in binary_channel_names and animation.frames:
             all_ids = (
                 list(animation.frames[0].transforms.keys()) if n_frames > 0 else []
             )
@@ -749,33 +749,75 @@ class ViewerClient:
                     for obj_id, matrix in frame.transforms.items():
                         transform_data[fi, id_to_idx[obj_id], :] = matrix
 
-        # Build sparse channel metadata from Frame objects
-        has_binary_draw_ranges = animation._draw_range_data is not None
+            from .animation import AnimationChannel
+
+            channels.append(
+                AnimationChannel(
+                    name="transforms",
+                    ids=list(all_ids),
+                    data=transform_data,
+                    dtype="float32",
+                    stride=16,
+                    metadata=None,
+                )
+            )
+            binary_channel_names.add("transforms")
+
+        # Build sparse channel metadata from Frame objects (skip binary channels)
         frames_meta = []
         for fi, frame in enumerate(animation.frames):
             meta = {}
-            if frame.colors:
+            if frame.colors and "colors" not in binary_channel_names:
                 meta["colors"] = frame.colors
-            if frame.visibility:
+            if frame.visibility and "visibility" not in binary_channel_names:
                 meta["visibility"] = frame.visibility
-            if frame.opacity:
+            if frame.opacity and "opacity" not in binary_channel_names:
                 meta["opacity"] = frame.opacity
             if frame.clip_times:
                 meta["clip_times"] = frame.clip_times
-            if frame.draw_ranges and not has_binary_draw_ranges:
+            if frame.draw_ranges and "draw_ranges" not in binary_channel_names:
                 meta["draw_ranges"] = frame.draw_ranges
             if meta:
                 meta["index"] = fi
                 frames_meta.append(meta)
 
-        # Pack binary payload: transforms + optional draw_ranges
-        binary_payload = np.ascontiguousarray(
-            transform_data, dtype=np.float32
-        ).tobytes()
-        if has_binary_draw_ranges:
-            binary_payload += np.ascontiguousarray(
-                animation._draw_range_data, dtype=np.float32
-            ).tobytes()
+        # Warn if large JSON frames_meta could be replaced by binary channels
+        meta_entry_count = sum(
+            sum(len(v) for k, v in meta.items() if k != "index" and isinstance(v, dict))
+            for meta in frames_meta
+        )
+        if meta_entry_count > 10_000:
+            logger = logging.getLogger(__name__)
+            logger.info(
+                "Animation has %d JSON per-frame entries in frames_meta. "
+                "Consider using animation.add_channel() for colors/visibility/"
+                "opacity/draw_ranges for much faster serialization.",
+                meta_entry_count,
+            )
+
+        # Build binary payload from channels
+        # Sort by dtype byte size descending (float32/uint32 first, uint8 last)
+        # to avoid alignment padding between channels.
+        dtype_bytes = {"float32": 4, "uint32": 4, "uint8": 1}
+        sorted_channels = sorted(channels, key=lambda ch: -dtype_bytes[ch.dtype])
+        np_dtypes = {"float32": np.float32, "uint32": np.uint32, "uint8": np.uint8}
+
+        binary_parts = []
+        channel_manifest = []
+        for ch in sorted_channels:
+            packed = np.ascontiguousarray(ch.data, dtype=np_dtypes[ch.dtype]).tobytes()
+            binary_parts.append(packed)
+            entry = {
+                "name": ch.name,
+                "ids": ch.ids,
+                "dtype": ch.dtype,
+                "stride": ch.stride,
+            }
+            if ch.metadata:
+                entry.update(ch.metadata)
+            channel_manifest.append(entry)
+
+        binary_payload = b"".join(binary_parts)
 
         # Serve binary via HTTP (fast native transfer) instead of WebSocket
         # Clear old animation blobs in-place (keep object blobs like polylines/meshes)
@@ -785,8 +827,11 @@ class ViewerClient:
         self._blob_store[blob_key] = binary_payload
         blob_url = f"http://{self.host}:{self._http_port}{blob_key}"
 
-        # Store JSON version for reconnect (skip for large binary-only animations)
-        if animation.frames:
+        # Skip JSON reconvert for reconnect when binary channels are used
+        # (the JSON-based to_dict() path is exactly the bloat problem we're avoiding)
+        if channels:
+            self._current_animation = None
+        elif animation.frames:
             self._current_animation = animation.to_dict()
         else:
             self._current_animation = None
@@ -795,7 +840,6 @@ class ViewerClient:
         header = {
             "type": "load_animation_http",
             "blob_url": blob_url,
-            "object_ids": all_ids,
             "frame_count": n_frames,
             "frame_times": frame_times,
             "duration": animation.duration,
@@ -805,10 +849,9 @@ class ViewerClient:
                 {"time": m.time, "label": m.label, "color": m.color}
                 for m in animation.markers
             ],
+            "channels": channel_manifest,
             "frames_meta": frames_meta,
         }
-        if has_binary_draw_ranges:
-            header["draw_range_ids"] = animation._draw_range_ids
         self._send(header)
 
     def stop_animation(self) -> None:

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -507,7 +507,9 @@
                 }
             }
 
-            // Apply JSON-based frame channels (sparse per-frame metadata)
+            // Apply JSON-based frame channels (sparse per-frame metadata).
+            // No overlap with binary channels: the Python side filters frames_meta
+            // to exclude fields that have a binary channel (see binary_channel_names).
             if (frame.transforms) {
                 for (const [id, matrix] of Object.entries(frame.transforms)) {
                     const obj = objects.get(id);
@@ -1076,6 +1078,7 @@
                                 if (data.channels) {
                                     for (const ch of data.channels) {
                                         const info = DTYPE_INFO[ch.dtype];
+                                        if (!info) { console.error(`Unknown channel dtype '${ch.dtype}' for '${ch.name}', skipping`); continue; }
                                         const count = nFrames * ch.ids.length * ch.stride;
                                         channels[ch.name] = {
                                             data: new info.ArrayType(buffer, byteOffset, count),

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -347,17 +347,15 @@
             animationPlaying = false;
             lastAnimationUpdate = performance.now();
 
-            // Pre-build object reference array for binary animations (avoids Map.get per object per frame)
-            if (animation.binaryTransforms && animation.objectIds) {
-                const refs = new Array(animation.nObjects);
-                for (let i = 0; i < animation.nObjects; i++) {
-                    const obj = objects.get(animation.objectIds[i]);
-                    refs[i] = obj || null;
-                    if (obj) {
-                        obj.matrixAutoUpdate = false;
-                    }
+            // Pre-build object reference arrays for each binary channel
+            if (animation.channels) {
+                for (const [name, ch] of Object.entries(animation.channels)) {
+                    ch.refs = ch.ids.map(id => {
+                        const obj = objects.get(id);
+                        if (obj && name === 'transforms') obj.matrixAutoUpdate = false;
+                        return obj || null;
+                    });
                 }
-                animation.objectRefs = refs;
             }
 
             // Pre-compute frame time step for O(1) frame lookup (assumes uniform FPS)
@@ -417,34 +415,100 @@
             animControlsEl.classList.remove('visible');
         }
 
+        // Channel apply functions — keyed by channel name
+        const CHANNEL_APPLY = {
+            transforms(ch, refs, base) {
+                const nObj = ch.ids.length;
+                for (let i = 0; i < nObj; i++) {
+                    let obj = refs[i];
+                    if (!obj) {
+                        obj = objects.get(ch.ids[i]);
+                        if (obj) { refs[i] = obj; obj.matrixAutoUpdate = false; }
+                    }
+                    if (obj) {
+                        obj.matrix.fromArray(ch.data, base + i * 16);
+                        obj.matrixWorldNeedsUpdate = true;
+                    }
+                }
+            },
+
+            colors(ch, refs, base) {
+                const nObj = ch.ids.length;
+                const colormap = ch.colormap;
+                for (let i = 0; i < nObj; i++) {
+                    const raw = ch.data[base + i];
+                    const color = colormap ? colormap[raw] : raw;
+                    let obj = refs[i];
+                    if (!obj) { obj = objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                    if (obj) {
+                        obj.traverse(child => {
+                            if (child.material) child.material.color.setHex(color);
+                        });
+                    }
+                }
+            },
+
+            visibility(ch, refs, base) {
+                const nObj = ch.ids.length;
+                for (let i = 0; i < nObj; i++) {
+                    let obj = refs[i];
+                    if (!obj) { obj = objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                    if (obj) obj.visible = (ch.data[base + i] === 1);
+                }
+            },
+
+            draw_ranges(ch, refs, base) {
+                const nObj = ch.ids.length;
+                for (let i = 0; i < nObj; i++) {
+                    setDrawRange(ch.ids[i], ch.data[base + i]);
+                }
+            },
+
+            opacity(ch, refs, base) {
+                const nObj = ch.ids.length;
+                for (let i = 0; i < nObj; i++) {
+                    const val = ch.data[base + i];
+                    let obj = refs[i];
+                    if (!obj) { obj = objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                    if (obj) {
+                        obj.traverse(child => {
+                            if (child.material) {
+                                child.material.transparent = val < 1;
+                                child.material.opacity = val;
+                            }
+                        });
+                    }
+                }
+            },
+        };
+
         function applyFrame(frameIndex) {
             if (!animation || frameIndex < 0 || frameIndex >= animation.frames.length) return;
 
             const frame = animation.frames[frameIndex];
 
-            // Apply transforms
-            if (animation.binaryTransforms) {
-                // Fast path: read directly from Float32Array with pre-built object refs
-                const floatData = animation.binaryTransforms;
-                const refs = animation.objectRefs;
-                const nObjects = animation.nObjects;
-                const baseOffset = frameIndex * nObjects * 16;
-                for (let oi = 0; oi < nObjects; oi++) {
-                    let obj = refs[oi];
-                    if (!obj) {
-                        // Lazily resolve objects that loaded after animation started
-                        obj = objects.get(animation.objectIds[oi]);
-                        if (obj) {
-                            refs[oi] = obj;
-                            obj.matrixAutoUpdate = false;
-                        }
-                    }
-                    if (obj) {
-                        obj.matrix.fromArray(floatData, baseOffset + oi * 16);
-                        obj.matrixWorldNeedsUpdate = true;
+            // Apply binary channels
+            if (animation.channels) {
+                // Restore baseline visibility before applying visibility channel
+                if (animation.channels.visibility) {
+                    for (const [id, baselineVisible] of baselineVisibility) {
+                        const obj = objects.get(id);
+                        if (obj) obj.visible = baselineVisible;
                     }
                 }
-            } else if (frame.transforms) {
+
+                for (const [name, ch] of Object.entries(animation.channels)) {
+                    const applyFn = CHANNEL_APPLY[name];
+                    if (applyFn) {
+                        const nObj = ch.ids.length;
+                        const base = frameIndex * nObj * ch.stride;
+                        applyFn(ch, ch.refs, base);
+                    }
+                }
+            }
+
+            // Apply JSON-based frame channels (sparse per-frame metadata)
+            if (frame.transforms) {
                 for (const [id, matrix] of Object.entries(frame.transforms)) {
                     const obj = objects.get(id);
                     if (obj) {
@@ -455,38 +519,31 @@
                 }
             }
 
-            // Apply colors
             if (frame.colors) {
                 for (const [id, color] of Object.entries(frame.colors)) {
                     const obj = objects.get(id);
                     if (obj) {
                         obj.traverse((child) => {
-                            if (child.material) {
-                                child.material.color.setHex(color);
-                            }
+                            if (child.material) child.material.color.setHex(color);
                         });
                     }
                 }
             }
 
-            // Apply visibility: first restore baseline, then apply frame-specific changes
-            // This ensures hidden objects reappear when scrubbing to frames that don't mention them
-            for (const [id, baselineVisible] of baselineVisibility) {
-                const obj = objects.get(id);
-                if (obj) {
-                    obj.visible = baselineVisible;
+            // Restore baseline visibility for JSON-based visibility (when no binary visibility channel)
+            if (!animation.channels || !animation.channels.visibility) {
+                for (const [id, baselineVisible] of baselineVisibility) {
+                    const obj = objects.get(id);
+                    if (obj) obj.visible = baselineVisible;
                 }
             }
             if (frame.visibility) {
                 for (const [id, visible] of Object.entries(frame.visibility)) {
                     const obj = objects.get(id);
-                    if (obj) {
-                        obj.visible = visible;
-                    }
+                    if (obj) obj.visible = visible;
                 }
             }
 
-            // Apply opacity
             if (frame.opacity) {
                 for (const [id, opacity] of Object.entries(frame.opacity)) {
                     const obj = objects.get(id);
@@ -501,25 +558,12 @@
                 }
             }
 
-            // Apply clip times (embedded GLTF animations)
             if (frame.clip_times) {
                 for (const [id, time] of Object.entries(frame.clip_times)) {
                     setClipTime(id, time);
                 }
             }
 
-            // Apply binary draw ranges (bulk)
-            if (animation.binaryDrawRanges) {
-                const drData = animation.binaryDrawRanges;
-                const drIds = animation.drawRangeIds;
-                const nDR = drIds.length;
-                const base = frameIndex * nDR;
-                for (let i = 0; i < nDR; i++) {
-                    setDrawRange(drIds[i], drData[base + i]);
-                }
-            }
-
-            // Apply draw ranges (visibility fraction — sparse overrides)
             if (frame.draw_ranges) {
                 for (const [id, value] of Object.entries(frame.draw_ranges)) {
                     setDrawRange(id, value);
@@ -960,7 +1004,15 @@
             ws.onerror = () => {};
 
             ws.onmessage = async (event) => {
+                const tParse = performance.now();
                 const data = JSON.parse(event.data);
+                const parseMs = performance.now() - tParse;
+                if (parseMs > 200) {
+                    console.warn(
+                        `JSON.parse took ${parseMs.toFixed(0)}ms (${(event.data.length / 1024 / 1024).toFixed(1)}MB). ` +
+                        `Consider using binary channels (animation.add_channel()) for large animation data.`
+                    );
+                }
 
                 switch (data.type) {
                     case 'add_object':
@@ -1010,22 +1062,34 @@
                                 const t1 = performance.now();
                                 console.log(`HTTP animation fetch: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB in ${(t1 - t0).toFixed(0)}ms`);
 
-                                const objectIds = data.object_ids;
-                                const nObjects = objectIds.length;
                                 const nFrames = data.frame_count;
 
-                                // Split binary: transforms then optional draw_ranges
-                                const nTransformFloats = nFrames * nObjects * 16;
-                                const transformData = new Float32Array(buffer, 0, nTransformFloats);
+                                // Parse generic binary channels from manifest
+                                const DTYPE_INFO = {
+                                    float32: { ArrayType: Float32Array, bytes: 4 },
+                                    uint32:  { ArrayType: Uint32Array,  bytes: 4 },
+                                    uint8:   { ArrayType: Uint8Array,   bytes: 1 },
+                                };
 
-                                let drawRangeData = null;
-                                let drawRangeIds = null;
-                                if (data.draw_range_ids) {
-                                    drawRangeIds = data.draw_range_ids;
-                                    const drByteOffset = nTransformFloats * 4;
-                                    drawRangeData = new Float32Array(buffer, drByteOffset);
+                                let byteOffset = 0;
+                                const channels = {};
+                                if (data.channels) {
+                                    for (const ch of data.channels) {
+                                        const info = DTYPE_INFO[ch.dtype];
+                                        const count = nFrames * ch.ids.length * ch.stride;
+                                        channels[ch.name] = {
+                                            data: new info.ArrayType(buffer, byteOffset, count),
+                                            ids: ch.ids,
+                                            stride: ch.stride,
+                                            refs: null,
+                                            colormap: ch.colormap || null,
+                                        };
+                                        byteOffset += count * info.bytes;
+                                    }
                                 }
 
+                                // Build sparse frames from frames_meta
+                                const tMeta = performance.now();
                                 const metaByFrame = {};
                                 if (data.frames_meta) {
                                     for (const meta of data.frames_meta) {
@@ -1047,17 +1111,22 @@
                                     frames.push(frame);
                                 }
 
+                                const metaMs = performance.now() - tMeta;
+                                if (metaMs > 500) {
+                                    console.warn(
+                                        `frames_meta processing took ${metaMs.toFixed(0)}ms. ` +
+                                        `Consider using animation.add_channel() on the Python side ` +
+                                        `for colors/visibility/opacity/draw_ranges for much faster transfer.`
+                                    );
+                                }
+
                                 loadAnimation({
                                     duration: data.duration,
                                     fps: data.fps,
                                     loop: data.loop,
                                     frames: frames,
                                     markers: data.markers || [],
-                                    binaryTransforms: transformData,
-                                    objectIds: objectIds,
-                                    nObjects: nObjects,
-                                    binaryDrawRanges: drawRangeData,
-                                    drawRangeIds: drawRangeIds,
+                                    channels: channels,
                                 });
                                 console.log(`  total: ${(performance.now() - t0).toFixed(0)}ms`);
                             } catch (e) {

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from threejs_viewer import Animation, Frame, Marker
+from threejs_viewer import Animation, AnimationChannel, Frame, Marker
 
 
 def test_frame_creation():
@@ -79,27 +79,153 @@ def test_animation_to_dict():
     assert data["markers"][0]["label"] == "Halfway"
 
 
-def test_binary_animation_channels():
-    """Test binary animation data (set_frame_times, set_transform_data, set_draw_range_data)."""
+# --- Binary channel tests ---
+
+
+def test_set_transform_data():
+    """Test set_transform_data convenience wrapper creates a transforms channel."""
     animation = Animation(loop=True)
+    animation.set_frame_times(np.linspace(0, 10, 100))
 
-    n_frames = 100
-    n_objects = 2
-    times = np.linspace(0, 10, n_frames)
-    animation.set_frame_times(times)
-
-    transforms = np.zeros((n_frames, n_objects, 16), dtype=np.float32)
-    transforms[:, :, [0, 5, 10, 15]] = 1.0  # identity matrices
+    transforms = np.zeros((100, 2, 16), dtype=np.float32)
+    transforms[:, :, [0, 5, 10, 15]] = 1.0
     animation.set_transform_data(["obj_a", "obj_b"], transforms)
-
-    draw_ranges = (
-        np.linspace(0, 1, n_frames * 1).reshape(n_frames, 1).astype(np.float32)
-    )
-    draw_ranges = np.column_stack([draw_ranges, draw_ranges])
-    animation.set_draw_range_data(["obj_a", "obj_b"], draw_ranges)
 
     assert animation.n_frames == 100
     assert animation.duration == 10.0
-    assert animation.fps > 0
-    assert animation._object_ids == ["obj_a", "obj_b"]
-    assert animation._draw_range_ids == ["obj_a", "obj_b"]
+    assert len(animation._channels) == 1
+    assert animation._channels[0].name == "transforms"
+    assert animation._channels[0].ids == ["obj_a", "obj_b"]
+    assert animation._channels[0].dtype == "float32"
+    assert animation._channels[0].stride == 16
+
+
+def test_set_draw_range_data():
+    """Test set_draw_range_data convenience wrapper creates a draw_ranges channel."""
+    animation = Animation(loop=True)
+    animation.set_frame_times(np.linspace(0, 5, 50))
+
+    draw_ranges = np.linspace(0, 1, 50).reshape(50, 1).astype(np.float32)
+    draw_ranges = np.column_stack([draw_ranges, draw_ranges])
+    animation.set_draw_range_data(["obj_a", "obj_b"], draw_ranges)
+
+    assert len(animation._channels) == 1
+    assert animation._channels[0].name == "draw_ranges"
+    assert animation._channels[0].dtype == "float32"
+    assert animation._channels[0].stride == 1
+
+
+def test_add_channel_generic():
+    """Test add_channel with custom channel types."""
+    animation = Animation(loop=True)
+    animation.set_frame_times(np.arange(10) / 30.0)
+
+    # Colors with colormap
+    color_data = np.zeros((10, 3), dtype=np.uint8)
+    animation.add_channel(
+        "colors",
+        ["s0", "s1", "s2"],
+        color_data,
+        dtype="uint8",
+        metadata={"colormap": [0x44AA44, 0xFF3333]},
+    )
+
+    # Visibility
+    vis_data = np.ones((10, 3), dtype=np.uint8)
+    animation.add_channel("visibility", ["s0", "s1", "s2"], vis_data, dtype="uint8")
+
+    # Opacity
+    opacity_data = np.ones((10, 2), dtype=np.float32)
+    animation.add_channel("opacity", ["s0", "s1"], opacity_data, dtype="float32")
+
+    assert len(animation._channels) == 3
+    assert animation._channels[0].name == "colors"
+    assert animation._channels[0].metadata == {"colormap": [0x44AA44, 0xFF3333]}
+    assert animation._channels[1].name == "visibility"
+    assert animation._channels[2].name == "opacity"
+
+
+def test_add_channel_duplicate_replaces():
+    """Test that adding a channel with the same name replaces the existing one."""
+    animation = Animation(loop=True)
+    animation.set_frame_times(np.arange(5) / 30.0)
+
+    animation.set_transform_data(["a", "b"], np.zeros((5, 2, 16), dtype=np.float32))
+    assert len(animation._channels) == 1
+    assert len(animation._channels[0].ids) == 2
+
+    # Replace with a 3-object version
+    animation.set_transform_data(["a", "b", "c"], np.ones((5, 3, 16), dtype=np.float32))
+    assert len(animation._channels) == 1
+    assert len(animation._channels[0].ids) == 3
+
+
+def test_animation_channel_dataclass():
+    """Test AnimationChannel dataclass."""
+    ch = AnimationChannel(
+        name="test",
+        ids=["a", "b"],
+        data=np.zeros((10, 2), dtype=np.float32),
+        dtype="float32",
+        stride=1,
+        metadata=None,
+    )
+    assert ch.name == "test"
+    assert ch.ids == ["a", "b"]
+    assert ch.dtype == "float32"
+    assert ch.stride == 1
+    assert ch.metadata is None
+
+
+def test_multiple_channels_coexist():
+    """Test that transforms, draw_ranges, colors, and visibility can coexist."""
+    animation = Animation(loop=True)
+    n_frames = 20
+    animation.set_frame_times(np.arange(n_frames) / 60.0)
+
+    ids = ["obj1", "obj2"]
+    animation.set_transform_data(ids, np.zeros((n_frames, 2, 16), dtype=np.float32))
+    animation.set_draw_range_data(ids, np.ones((n_frames, 2), dtype=np.float32))
+    animation.add_channel(
+        "colors",
+        ids,
+        np.zeros((n_frames, 2), dtype=np.uint8),
+        dtype="uint8",
+        metadata={"colormap": [0x00FF00, 0xFF0000]},
+    )
+    animation.add_channel(
+        "visibility", ids, np.ones((n_frames, 2), dtype=np.uint8), dtype="uint8"
+    )
+
+    assert len(animation._channels) == 4
+    names = [ch.name for ch in animation._channels]
+    assert "transforms" in names
+    assert "draw_ranges" in names
+    assert "colors" in names
+    assert "visibility" in names
+
+
+def test_binary_channels_with_frame_objects():
+    """Test that binary channels and Frame objects can coexist (mixed mode)."""
+    animation = Animation(loop=True)
+
+    # Frames with clip_times (no binary channel for this)
+    for i in range(5):
+        animation.add_frame(
+            time=i / 30.0,
+            transforms={"obj1": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]},
+            clip_times={"model1": i * 0.1},
+        )
+
+    # Binary colors channel alongside Frame-based clip_times
+    animation.add_channel(
+        "colors",
+        ["obj1"],
+        np.zeros((5, 1), dtype=np.uint8),
+        dtype="uint8",
+        metadata={"colormap": [0x44AA44, 0xFF3333]},
+    )
+
+    assert animation.n_frames == 5
+    assert len(animation._channels) == 1
+    assert animation.frames[0].clip_times == {"model1": 0.0}

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Replaces bespoke `binaryTransforms` / `binaryDrawRanges` fields with a self-describing channel manifest system (`animation.add_channel()`)
- Adds `AnimationChannel` dataclass and `CHANNEL_APPLY` dispatch table in JS for extensible channel types
- Supports `transforms`, `draw_ranges`, `colors`, `visibility`, and `opacity` channels with `float32`, `uint32`, `uint8` dtypes
- Frame-based JSON path preserved for simple animations; binary channels and Frame objects can be mixed
- Updates examples 05 (opacity channel for trail fade) and 10 (indexed colormap + dynamic scale)
- Adds performance warnings on both Python and JS sides for large JSON payloads
- 22 tests passing, documentation updated

## Test plan
- [x] `uv run pytest` — 22 tests pass
- [x] Run `examples/05_lissajous_curves.py` — verify opacity trail fade
- [x] Run `examples/10_animation_stress_test.py` — verify colormap + dynamic scale
- [x] Run `examples/11_toolpath.py` — verify draw_range animation
- [x] Run `examples/03_animation_basics.py` — verify Frame-based path still works