### PR TITLE
Add transparency support

### DIFF
--- a/examples/12_transparency.py
+++ b/examples/12_transparency.py
@@ -100,24 +100,9 @@ all_opacity = np.column_stack(
     ]
 ).astype(np.float32)
 
-# Identity transforms (objects stay in place)
-transforms = np.zeros((n_frames, len(object_ids), 16), dtype=np.float32)
-transforms[:, :, [0, 5, 10, 15]] = 1.0
-# Helmet at z=1
-transforms[:, 0, 14] = 1.0
-# Sphere at (-2, 0, 0.5)
-transforms[:, 1, 12] = -2.0
-transforms[:, 1, 14] = 0.5
-# Box at (2, 0, 0.5)
-transforms[:, 2, 12] = 2.0
-transforms[:, 2, 14] = 0.5
-# Cylinder at (0, -2, 0.5)
-transforms[:, 3, 13] = -2.0
-transforms[:, 3, 14] = 0.5
-
+# Opacity-only animation — no transforms needed, objects stay where they were placed
 animation = Animation(loop=True)
 animation.set_frame_times(frame_times)
-animation.set_transform_data(object_ids, transforms)
 animation.add_channel("opacity", object_ids, all_opacity, dtype="float32")
 
 animation.add_marker(0.0, "Opaque", color=0x00FF00)

--- a/examples/12_transparency.py
+++ b/examples/12_transparency.py
@@ -48,9 +48,13 @@ v.add_box(
     "ground", width=10, height=10, depth=0.02, color=0x333333, position=[0, 0, -0.01]
 )
 
-# Load GLB model
-v.add_model_binary("helmet", helmet_path, format="glb")
-v.set_matrix("helmet", [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1])
+# Load GLB model — rotate 90° about X so it faces up (Z-up convention)
+v.add_model_binary(
+    "helmet",
+    helmet_path,
+    format="glb",
+    matrix=[-1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1.5, 1],
+)
 
 # Primitives with initial opacity
 v.add_sphere(

--- a/examples/12_transparency.py
+++ b/examples/12_transparency.py
@@ -5,8 +5,8 @@ Loads a GLB model and pulses its opacity using the binary opacity animation
 channel. Also shows primitives with initial opacity.
 
 Demonstrates:
+- opacity parameter on primitives (add_sphere, add_box, add_cylinder)
 - set_opacity() for one-shot opacity changes
-- opacity parameter on primitives (add_sphere, add_box)
 - Binary opacity animation channel for smooth pulsing
 
 Run: uv run python examples/12_transparency.py
@@ -78,6 +78,9 @@ v.add_cylinder(
     opacity=0.4,
     position=[0, -2, 0.5],
 )
+
+# One-shot opacity change (before animation takes over)
+v.set_opacity("helmet", 0.5)
 
 # Animate: pulse helmet opacity + keep primitives at varying opacity
 duration = 6.0

--- a/examples/12_transparency.py
+++ b/examples/12_transparency.py
@@ -1,0 +1,135 @@
+"""
+Transparency Demo
+
+Loads a GLB model and pulses its opacity using the binary opacity animation
+channel. Also shows primitives with initial opacity.
+
+Demonstrates:
+- set_opacity() for one-shot opacity changes
+- opacity parameter on primitives (add_sphere, add_box)
+- Binary opacity animation channel for smooth pulsing
+
+Run: uv run python examples/12_transparency.py
+"""
+
+import math
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+from threejs_viewer import Animation, viewer
+
+CACHE_DIR = Path(__file__).parent / "tmp"
+MODEL_URL = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"
+
+
+def download_model() -> Path:
+    """Download the DamagedHelmet GLB if not already cached."""
+    CACHE_DIR.mkdir(exist_ok=True)
+    path = CACHE_DIR / "helmet.glb"
+    if path.exists():
+        print("  helmet: cached")
+        return path
+    print("  helmet: downloading...")
+    urllib.request.urlretrieve(MODEL_URL, path)
+    print(f"  helmet: {path.stat().st_size / 1024:.0f} KB")
+    return path
+
+
+print("Downloading GLB model...")
+helmet_path = download_model()
+
+v = viewer()
+v.clear()
+
+# Ground plane
+v.add_box(
+    "ground", width=10, height=10, depth=0.02, color=0x333333, position=[0, 0, -0.01]
+)
+
+# Load GLB model
+v.add_model_binary("helmet", helmet_path, format="glb")
+v.set_matrix("helmet", [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1])
+
+# Primitives with initial opacity
+v.add_sphere(
+    "ghost_sphere", radius=0.5, color=0x4488FF, opacity=0.4, position=[-2, 0, 0.5]
+)
+v.add_box(
+    "ghost_box",
+    width=0.8,
+    height=0.8,
+    depth=0.8,
+    color=0xFF4444,
+    opacity=0.4,
+    position=[2, 0, 0.5],
+)
+v.add_cylinder(
+    "ghost_cyl",
+    radius_top=0.3,
+    radius_bottom=0.3,
+    height=1,
+    color=0x44FF44,
+    opacity=0.4,
+    position=[0, -2, 0.5],
+)
+
+# Animate: pulse helmet opacity + keep primitives at varying opacity
+duration = 6.0
+fps = 60
+n_frames = int(duration * fps)
+frame_times = np.arange(n_frames) / fps
+
+# Helmet: smooth pulse between 0.2 and 1.0
+t_norm = frame_times / duration
+helmet_opacity = 0.6 + 0.4 * np.cos(2 * math.pi * t_norm)
+
+# Primitives: staggered sine waves
+sphere_opacity = 0.3 + 0.7 * np.abs(np.sin(2 * math.pi * t_norm))
+box_opacity = 0.3 + 0.7 * np.abs(np.sin(2 * math.pi * t_norm + math.pi / 3))
+cyl_opacity = 0.3 + 0.7 * np.abs(np.sin(2 * math.pi * t_norm + 2 * math.pi / 3))
+
+object_ids = ["helmet", "ghost_sphere", "ghost_box", "ghost_cyl"]
+all_opacity = np.column_stack(
+    [
+        helmet_opacity,
+        sphere_opacity,
+        box_opacity,
+        cyl_opacity,
+    ]
+).astype(np.float32)
+
+# Identity transforms (objects stay in place)
+transforms = np.zeros((n_frames, len(object_ids), 16), dtype=np.float32)
+transforms[:, :, [0, 5, 10, 15]] = 1.0
+# Helmet at z=1
+transforms[:, 0, 14] = 1.0
+# Sphere at (-2, 0, 0.5)
+transforms[:, 1, 12] = -2.0
+transforms[:, 1, 14] = 0.5
+# Box at (2, 0, 0.5)
+transforms[:, 2, 12] = 2.0
+transforms[:, 2, 14] = 0.5
+# Cylinder at (0, -2, 0.5)
+transforms[:, 3, 13] = -2.0
+transforms[:, 3, 14] = 0.5
+
+animation = Animation(loop=True)
+animation.set_frame_times(frame_times)
+animation.set_transform_data(object_ids, transforms)
+animation.add_channel("opacity", object_ids, all_opacity, dtype="float32")
+
+animation.add_marker(0.0, "Opaque", color=0x00FF00)
+animation.add_marker(duration / 2, "Translucent", color=0x0088FF)
+
+v.load_animation(animation)
+
+print(f"Pulsing opacity: {n_frames} frames at {fps} fps")
+print("Press Ctrl+C to exit.")
+
+try:
+    while True:
+        pass
+except KeyboardInterrupt:
+    v.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.3"
+version = "0.0.4"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -311,6 +311,10 @@ class ViewerClient:
         id: str,
         path_or_bytes: Union[str, Path, bytes],
         format: str = "stl",
+        position: Optional[List[float]] = None,
+        rotation: Optional[List[float]] = None,
+        scale: Optional[List[float]] = None,
+        matrix: Optional[List[float]] = None,
     ) -> None:
         """
         Add a 3D model to the scene by sending file bytes over WebSocket.
@@ -319,6 +323,10 @@ class ViewerClient:
             id: Unique identifier for the object
             path_or_bytes: Path to mesh file, or raw mesh bytes
             format: Model format (stl, gltf, glb, obj, fbx, dae, ply, 3ds)
+            position: [x, y, z] position
+            rotation: [x, y, z] Euler rotation in radians
+            scale: [x, y, z] scale
+            matrix: Column-major 4x4 transform matrix (overrides position/rotation/scale)
         """
         if isinstance(path_or_bytes, bytes):
             mesh_bytes = path_or_bytes
@@ -328,10 +336,20 @@ class ViewerClient:
                 raise FileNotFoundError(f"Mesh file not found: {path}")
             mesh_bytes = path.read_bytes()
 
-        self._send_binary(
-            {"type": "add_model_binary", "id": id, "format": format},
-            mesh_bytes,
-        )
+        header = {"type": "add_model_binary", "id": id, "format": format}
+        if matrix:
+            header["transform"] = {"matrix": matrix}
+        elif position or rotation or scale:
+            transform = {}
+            if position:
+                transform["position"] = position
+            if rotation:
+                transform["rotation"] = rotation
+            if scale:
+                transform["scale"] = scale
+            header["transform"] = transform
+
+        self._send_binary(header, mesh_bytes)
 
     def add_polyline(
         self,

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -169,6 +169,7 @@ class ViewerClient:
         height: float = 1,
         depth: float = 1,
         color: int = 0x4A90D9,
+        opacity: float = 1.0,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
@@ -177,7 +178,13 @@ class ViewerClient:
         self._add_primitive(
             id,
             "box",
-            {"width": width, "height": height, "depth": depth, "color": color},
+            {
+                "width": width,
+                "height": height,
+                "depth": depth,
+                "color": color,
+                "opacity": opacity,
+            },
             position,
             rotation,
             scale,
@@ -188,13 +195,19 @@ class ViewerClient:
         id: str,
         radius: float = 0.5,
         color: int = 0x4A90D9,
+        opacity: float = 1.0,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
     ) -> None:
         """Add a sphere primitive to the scene."""
         self._add_primitive(
-            id, "sphere", {"radius": radius, "color": color}, position, rotation, scale
+            id,
+            "sphere",
+            {"radius": radius, "color": color, "opacity": opacity},
+            position,
+            rotation,
+            scale,
         )
 
     def add_cylinder(
@@ -204,6 +217,7 @@ class ViewerClient:
         radius_bottom: float = 0.5,
         height: float = 1,
         color: int = 0x4A90D9,
+        opacity: float = 1.0,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
@@ -217,6 +231,7 @@ class ViewerClient:
                 "radiusBottom": radius_bottom,
                 "height": height,
                 "color": color,
+                "opacity": opacity,
             },
             position,
             rotation,
@@ -229,6 +244,7 @@ class ViewerClient:
         radius: float = 0.25,
         length: float = 0.5,
         color: int = 0x4A90D9,
+        opacity: float = 1.0,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
@@ -237,7 +253,7 @@ class ViewerClient:
         self._add_primitive(
             id,
             "capsule",
-            {"radius": radius, "length": length, "color": color},
+            {"radius": radius, "length": length, "color": color, "opacity": opacity},
             position,
             rotation,
             scale,
@@ -660,9 +676,16 @@ class ViewerClient:
         """Set object visibility."""
         self._send({"type": "set_visibility", "id": id, "visible": visible})
 
-    def set_color(self, id: str, color: int):
-        """Set object material color."""
-        self._send({"type": "set_color", "id": id, "color": color})
+    def set_color(self, id: str, color: int, opacity: float | None = None):
+        """Set object material color, and optionally opacity (0.0-1.0)."""
+        msg = {"type": "set_color", "id": id, "color": color}
+        if opacity is not None:
+            msg["opacity"] = float(opacity)
+        self._send(msg)
+
+    def set_opacity(self, id: str, opacity: float):
+        """Set object material opacity (0.0 = invisible, 1.0 = fully opaque)."""
+        self._send({"type": "set_opacity", "id": id, "opacity": float(opacity)})
 
     def set_clip_time(self, id: str, time: float):
         """Seek embedded GLTF/GLB animation clips to a specific time (seconds)."""

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -694,7 +694,7 @@ class ViewerClient:
         """Set object visibility."""
         self._send({"type": "set_visibility", "id": id, "visible": visible})
 
-    def set_color(self, id: str, color: int, opacity: float | None = None):
+    def set_color(self, id: str, color: int, opacity: Optional[float] = None):
         """Set object material color, and optionally opacity (0.0-1.0)."""
         msg = {"type": "set_color", "id": id, "color": color}
         if opacity is not None:

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -470,14 +470,7 @@
                     const val = ch.data[base + i];
                     let obj = refs[i];
                     if (!obj) { obj = objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
-                    if (obj) {
-                        obj.traverse(child => {
-                            if (child.material) {
-                                child.material.transparent = val < 1;
-                                child.material.opacity = val;
-                            }
-                        });
-                    }
+                    if (obj) applyOpacity(obj, val);
                 }
             },
         };
@@ -549,14 +542,7 @@
             if (frame.opacity) {
                 for (const [id, opacity] of Object.entries(frame.opacity)) {
                     const obj = objects.get(id);
-                    if (obj) {
-                        obj.traverse((child) => {
-                            if (child.material) {
-                                child.material.transparent = opacity < 1;
-                                child.material.opacity = opacity;
-                            }
-                        });
-                    }
+                    if (obj) applyOpacity(obj, opacity);
                 }
             }
 
@@ -815,14 +801,24 @@
             }
         }
 
-        // Set opacity on all materials of an object
+        // Set opacity on all materials of an object (handles GLB PBR materials)
         function setOpacity(id, opacity) {
             const obj = objects.get(id);
             if (!obj) return;
+            applyOpacity(obj, opacity);
+        }
+
+        function applyOpacity(obj, opacity) {
             obj.traverse(child => {
-                if (child.material) {
-                    child.material.transparent = opacity < 1;
-                    child.material.opacity = opacity;
+                if (!child.material) return;
+                const mats = Array.isArray(child.material) ? child.material : [child.material];
+                for (const mat of mats) {
+                    const wasTransparent = mat.transparent;
+                    mat.transparent = opacity < 1;
+                    mat.opacity = opacity;
+                    mat.depthWrite = opacity >= 1;
+                    // Three.js requires needsUpdate when transparent flag changes
+                    if (mat.transparent !== wasTransparent) mat.needsUpdate = true;
                 }
             });
         }
@@ -1058,12 +1054,9 @@
                             colorObj.traverse((child) => {
                                 if (child.material) {
                                     child.material.color.setHex(data.color);
-                                    if (data.opacity != null) {
-                                        child.material.transparent = data.opacity < 1;
-                                        child.material.opacity = data.opacity;
-                                    }
                                 }
                             });
+                            if (data.opacity != null) applyOpacity(colorObj, data.opacity);
                         }
                         break;
                     case 'set_opacity':

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1167,7 +1167,10 @@
                                     format: data.format || 'stl'
                                 });
                                 const obj = objects.get(data.id);
-                                if (obj) obj.userData.blobUrl = blobUrl;
+                                if (obj) {
+                                    obj.userData.blobUrl = blobUrl;
+                                    if (data.transform) updateTransform(data.id, data.transform);
+                                }
                             } catch (e) {
                                 console.error(`Error loading model via HTTP:`, e);
                             }

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -800,17 +800,31 @@
         function createMaterial(params) {
             const color = params.color || 0x4a90d9;
             const materialType = params.materialType || 'standard';
+            const opacity = params.opacity != null ? params.opacity : 1;
+            const transparent = opacity < 1;
 
             switch (materialType) {
                 case 'basic':
-                    return new THREE.MeshBasicMaterial({ color });
+                    return new THREE.MeshBasicMaterial({ color, opacity, transparent });
                 case 'phong':
-                    return new THREE.MeshPhongMaterial({ color });
+                    return new THREE.MeshPhongMaterial({ color, opacity, transparent });
                 case 'lambert':
-                    return new THREE.MeshLambertMaterial({ color });
+                    return new THREE.MeshLambertMaterial({ color, opacity, transparent });
                 default:
-                    return new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.3, envMapIntensity: 0 });
+                    return new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.3, envMapIntensity: 0, opacity, transparent });
             }
+        }
+
+        // Set opacity on all materials of an object
+        function setOpacity(id, opacity) {
+            const obj = objects.get(id);
+            if (!obj) return;
+            obj.traverse(child => {
+                if (child.material) {
+                    child.material.transparent = opacity < 1;
+                    child.material.opacity = opacity;
+                }
+            });
         }
 
         // Add object to scene
@@ -969,10 +983,13 @@
             }
         }
 
-        // Batch update transforms (for 60fps updates)
+        // Batch update transforms + optional opacity (for 60fps updates)
         function batchUpdate(transforms) {
             for (const [id, transform] of Object.entries(transforms)) {
                 updateTransform(id, transform);
+                if (transform.opacity != null) {
+                    setOpacity(id, transform.opacity);
+                }
             }
         }
 
@@ -1041,9 +1058,16 @@
                             colorObj.traverse((child) => {
                                 if (child.material) {
                                     child.material.color.setHex(data.color);
+                                    if (data.opacity != null) {
+                                        child.material.transparent = data.opacity < 1;
+                                        child.material.opacity = data.opacity;
+                                    }
                                 }
                             });
                         }
+                        break;
+                    case 'set_opacity':
+                        setOpacity(data.id, data.opacity);
                         break;
                     case 'list_objects':
                         ws.send(JSON.stringify({

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Add `set_opacity()` method and `opacity` parameter on primitives (`add_box`, `add_sphere`, `add_cylinder`, `add_capsule`)
- Extend `set_color()` with optional `opacity` argument
- Support opacity in `batch_update()` and binary animation channels
- Handle GLB/PBR materials correctly: `needsUpdate`, `depthWrite`, multi-material arrays via shared `applyOpacity()` helper
- Add `position/rotation/scale/matrix` transform parameters to `add_model_binary()` (applied after async load completes)
- New example `12_transparency.py`: GLB helmet + primitives with pulsing opacity animation

## Test plan
- [x] `uv run pytest` — 22 tests pass
- [x] `uv run ruff check` — clean
- [x] Manual test: `uv run python examples/12_transparency.py` — helmet and primitives pulse opacity smoothly
- [x] Existing examples unaffected (default opacity=1.0, no material changes)