### PR TITLE
Add roughness/metalness to primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ A lightweight Three.js viewer designed to be controlled from Python/Jupyter note
 - **Looping mode**: Pre-computed frames with interactive playback (`load_animation()`)
 
 ### Supported Object Types
-- Primitives: box, sphere, cylinder, plane, cone, torus, capsule
+- Primitives: box, sphere, cylinder, plane, cone, torus, capsule (with optional roughness/metalness)
 - Polylines: gradient-colored with colormaps (viridis, plasma, turbo)
 - Meshes: pre-built triangle meshes via `add_mesh()` with optional vertex colors and normals
 - Beads: toolpath extrusion via `add_bead()` — 6-vertex bevelled rectangle cross-section, vectorized numpy, per-layer vertex colors
@@ -80,3 +80,5 @@ Binary channels and Frame-based JSON can coexist (e.g. binary transforms + JSON 
 - `09_animated_glb.py` - Embedded GLTF animation via clip_times (AnimatedMorphCube + orbiting Avocado)
 - `10_animation_stress_test.py` - Animation stress test (520 objects × 2499 frames, vectorized numpy)
 - `11_toolpath.py` - Spiral vase toolpath with draw_range animation (polyline + bead mesh + nozzles, 800k points, alternating layer colors, binary animation channels)
+- `12_transparency.py` - Transparency and opacity control (set_opacity, set_color with opacity)
+- `13_material_properties.py` - PBR material properties (roughness/metalness grid on primitives)

--- a/examples/13_material_properties.py
+++ b/examples/13_material_properties.py
@@ -1,0 +1,63 @@
+"""
+Example 13: Material Properties (Roughness & Metalness)
+
+Grid of spheres varying roughness (columns) and metalness (rows)
+to demonstrate PBR material control on primitives. Also includes
+a metallic box and a rough cylinder.
+"""
+
+import time
+
+from threejs_viewer import viewer
+
+v = viewer()
+v.clear()
+
+# 5x5 grid of spheres: roughness varies across columns, metalness across rows
+n = 5
+spacing = 1.5
+base_color = 0xD4956A  # warm copper tone shows PBR well
+
+for row in range(n):
+    metalness = row / (n - 1)
+    for col in range(n):
+        roughness = col / (n - 1)
+        v.add_sphere(
+            f"sphere_{row}_{col}",
+            radius=0.5,
+            color=base_color,
+            roughness=roughness,
+            metalness=metalness,
+            position=[col * spacing, row * spacing, 0],
+        )
+
+# Metallic box
+v.add_box(
+    "metal_box",
+    width=1.2,
+    height=1.2,
+    depth=1.2,
+    color=0xC0C0C0,
+    roughness=0.1,
+    metalness=1.0,
+    position=[-2.5, 1.5, 0],
+)
+
+# Rough cylinder
+v.add_cylinder(
+    "rough_cylinder",
+    radius_top=0.5,
+    radius_bottom=0.5,
+    height=1.5,
+    color=0x8B4513,
+    roughness=1.0,
+    metalness=0.0,
+    position=[-2.5, 4.5, 0],
+)
+
+print("Material properties demo loaded.")
+print(f"Sphere grid: roughness 0→1 (left→right), metalness 0→1 (bottom→top)")
+print("Left column: metallic box (shiny) and rough cylinder (matte)")
+
+time.sleep(0.5)
+v.disconnect()

--- a/examples/13_material_properties.py
+++ b/examples/13_material_properties.py
@@ -56,7 +56,7 @@ v.add_cylinder(
 )
 
 print("Material properties demo loaded.")
-print(f"Sphere grid: roughness 0→1 (left→right), metalness 0→1 (bottom→top)")
+print("Sphere grid: roughness 0→1 (left→right), metalness 0→1 (bottom→top)")
 print("Left column: metallic box (shiny) and rough cylinder (matte)")
 
 time.sleep(0.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.4"
+version = "0.0.5"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "Marker",
 ]
 
-__version__ = "0.0.1"
+__version__ = "0.0.5"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -252,7 +252,12 @@ class ViewerClient:
         scale: Optional[List[float]] = None,
     ) -> None:
         """Add a capsule (pill) primitive to the scene."""
-        params = {"radius": radius, "length": length, "color": color, "opacity": opacity}
+        params = {
+            "radius": radius,
+            "length": length,
+            "color": color,
+            "opacity": opacity,
+        }
         if roughness is not None:
             params["roughness"] = roughness
         if metalness is not None:

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -170,25 +170,25 @@ class ViewerClient:
         depth: float = 1,
         color: int = 0x4A90D9,
         opacity: float = 1.0,
+        roughness: Optional[float] = None,
+        metalness: Optional[float] = None,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
     ) -> None:
         """Add a box primitive to the scene."""
-        self._add_primitive(
-            id,
-            "box",
-            {
-                "width": width,
-                "height": height,
-                "depth": depth,
-                "color": color,
-                "opacity": opacity,
-            },
-            position,
-            rotation,
-            scale,
-        )
+        params = {
+            "width": width,
+            "height": height,
+            "depth": depth,
+            "color": color,
+            "opacity": opacity,
+        }
+        if roughness is not None:
+            params["roughness"] = roughness
+        if metalness is not None:
+            params["metalness"] = metalness
+        self._add_primitive(id, "box", params, position, rotation, scale)
 
     def add_sphere(
         self,
@@ -196,19 +196,19 @@ class ViewerClient:
         radius: float = 0.5,
         color: int = 0x4A90D9,
         opacity: float = 1.0,
+        roughness: Optional[float] = None,
+        metalness: Optional[float] = None,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
     ) -> None:
         """Add a sphere primitive to the scene."""
-        self._add_primitive(
-            id,
-            "sphere",
-            {"radius": radius, "color": color, "opacity": opacity},
-            position,
-            rotation,
-            scale,
-        )
+        params = {"radius": radius, "color": color, "opacity": opacity}
+        if roughness is not None:
+            params["roughness"] = roughness
+        if metalness is not None:
+            params["metalness"] = metalness
+        self._add_primitive(id, "sphere", params, position, rotation, scale)
 
     def add_cylinder(
         self,
@@ -218,25 +218,25 @@ class ViewerClient:
         height: float = 1,
         color: int = 0x4A90D9,
         opacity: float = 1.0,
+        roughness: Optional[float] = None,
+        metalness: Optional[float] = None,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
     ) -> None:
         """Add a cylinder primitive to the scene."""
-        self._add_primitive(
-            id,
-            "cylinder",
-            {
-                "radiusTop": radius_top,
-                "radiusBottom": radius_bottom,
-                "height": height,
-                "color": color,
-                "opacity": opacity,
-            },
-            position,
-            rotation,
-            scale,
-        )
+        params = {
+            "radiusTop": radius_top,
+            "radiusBottom": radius_bottom,
+            "height": height,
+            "color": color,
+            "opacity": opacity,
+        }
+        if roughness is not None:
+            params["roughness"] = roughness
+        if metalness is not None:
+            params["metalness"] = metalness
+        self._add_primitive(id, "cylinder", params, position, rotation, scale)
 
     def add_capsule(
         self,
@@ -245,19 +245,19 @@ class ViewerClient:
         length: float = 0.5,
         color: int = 0x4A90D9,
         opacity: float = 1.0,
+        roughness: Optional[float] = None,
+        metalness: Optional[float] = None,
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
     ) -> None:
         """Add a capsule (pill) primitive to the scene."""
-        self._add_primitive(
-            id,
-            "capsule",
-            {"radius": radius, "length": length, "color": color, "opacity": opacity},
-            position,
-            rotation,
-            scale,
-        )
+        params = {"radius": radius, "length": length, "color": color, "opacity": opacity}
+        if roughness is not None:
+            params["roughness"] = roughness
+        if metalness is not None:
+            params["metalness"] = metalness
+        self._add_primitive(id, "capsule", params, position, rotation, scale)
 
     def add_model(
         self,

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -797,7 +797,9 @@
                 case 'lambert':
                     return new THREE.MeshLambertMaterial({ color, opacity, transparent });
                 default:
-                    return new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.3, envMapIntensity: 0, opacity, transparent });
+                    const roughness = params.roughness != null ? params.roughness : 0.7;
+                    const metalness = params.metalness != null ? params.metalness : 0.3;
+                    return new THREE.MeshStandardMaterial({ color, roughness, metalness, envMapIntensity: 0, opacity, transparent });
             }
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Primitives (box, sphere, cylinder, capsule) now accept optional `roughness` and `metalness` parameters, matching the existing `add_mesh()` API
- JS `createMaterial()` reads from params instead of hardcoding `0.7`/`0.3` — defaults unchanged when not specified
- New example 13: 5×5 sphere grid showing roughness/metalness gradients + metallic box + rough cylinder
- Version bump to 0.0.5 (syncs `__init__.py` which was at 0.0.1)

## Test plan
- [x] Run `uv run python examples/13_material_properties.py` — sphere grid should show visible PBR variation
- [x] Run `uv run python examples/01_primitives.py` — defaults should look identical to before