### PR TITLE
Add object grouping and version handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.0.7
+
+Adds object grouping (parent-child hierarchies) and version negotiation between Python client and browser viewer.
+
+### New features
+
+- **Object grouping** — `add_group(id, parent=...)` creates empty transform nodes; all `add_*` methods accept an optional `parent` parameter. Children inherit parent transforms automatically via Three.js scene graph. Deleting a group removes all children.
+- **Version handshake** — viewer and Python client exchange versions on connect. Mismatches print a warning on both sides, catching stale browser cache issues immediately.
+
+### New example
+
+- `14_grouping.py` — animated robot arm with nested groups (base → shoulder → elbow → wrist), demonstrating how only joint transforms need animation while visual meshes follow automatically
+
+### Updated examples
+
+- `01_primitives.py` — pillars grouped under a common parent
+- `03_animation_basics.py` — moon parented to earth_system group, uses local orbit offset instead of recomputing world position
+- `04_flying_teapots.py` — reference pillars grouped
+
 ## 0.0.6
 
 Enables environment map reflections on primitives and meshes, rebalances scene lighting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ A lightweight Three.js viewer designed to be controlled from Python/Jupyter note
 - **Looping mode**: Pre-computed frames with interactive playback (`load_animation()`)
 
 ### Supported Object Types
+- **Groups**: `add_group(id, parent=...)` — empty transform nodes for parent-child hierarchies. Children inherit parent transforms. All `add_*` methods accept an optional `parent` parameter.
 - Primitives: box, sphere, cylinder, plane, cone, torus, capsule (with optional roughness/metalness)
 - Polylines: gradient-colored with colormaps (viridis, plasma, turbo)
 - Meshes: pre-built triangle meshes via `add_mesh()` with optional vertex colors and normals
@@ -82,3 +83,4 @@ Binary channels and Frame-based JSON can coexist (e.g. binary transforms + JSON 
 - `11_toolpath.py` - Spiral vase toolpath with draw_range animation (polyline + bead mesh + nozzles, 800k points, alternating layer colors, binary animation channels)
 - `12_transparency.py` - Transparency and opacity control (set_opacity, set_color with opacity)
 - `13_material_properties.py` - PBR material properties (roughness/metalness grid on primitives)
+- `14_grouping.py` - Object grouping with animated robot arm (nested parent-child hierarchy, local joint transforms)

--- a/examples/01_primitives.py
+++ b/examples/01_primitives.py
@@ -56,7 +56,8 @@ for i in range(4):
         metalness=0.1,
     )
 
-# Add cylinders as "pillars"
+# Group cylinders as "pillars" — deleting "pillars" removes them all
+v.add_group("pillars")
 pillar_positions = [(-4, -4), (-4, 4), (4, -4), (4, 4)]
 for i, (x, y) in enumerate(pillar_positions):
     v.add_cylinder(
@@ -68,6 +69,7 @@ for i, (x, y) in enumerate(pillar_positions):
         position=[x, y, 1.0],
         roughness=0.3,
         metalness=0.7,
+        parent="pillars",
     )
 
 print("Scene created! Press Ctrl+C to exit.")

--- a/examples/03_animation_basics.py
+++ b/examples/03_animation_basics.py
@@ -95,8 +95,17 @@ for planet in planets:
         metalness=planet["metalness"],
     )
 
-# Also add a moon orbiting Earth
-v.add_sphere("moon", radius=0.08, color=0xCCCCCC, roughness=0.9, metalness=0.0)
+# Use a group for Earth so the moon inherits Earth's orbit automatically
+v.add_group("earth_system")
+# Moon as child of earth_system — only needs its local orbit offset
+v.add_sphere(
+    "moon",
+    radius=0.08,
+    color=0xCCCCCC,
+    roughness=0.9,
+    metalness=0.0,
+    parent="earth_system",
+)
 
 # Create animation frames
 duration = 10.0  # seconds
@@ -119,14 +128,16 @@ for i in range(n_frames):
         y = planet["orbit_radius"] * math.sin(angle)
         transforms[planet["id"]] = make_transform_matrix([x, y, 0])
 
-    # Moon orbits Earth
+    # Earth system group follows Earth's orbit
     earth_angle = 2 * math.pi * t / 5.0
     earth_x = 4.5 * math.cos(earth_angle)
     earth_y = 4.5 * math.sin(earth_angle)
+    transforms["earth_system"] = make_transform_matrix([earth_x, earth_y, 0])
 
+    # Moon only needs its LOCAL orbit offset — the group handles the rest
     moon_angle = 2 * math.pi * t / 0.8  # Fast orbit around earth
-    moon_x = earth_x + 0.6 * math.cos(moon_angle)
-    moon_y = earth_y + 0.6 * math.sin(moon_angle)
+    moon_x = 0.6 * math.cos(moon_angle)
+    moon_y = 0.6 * math.sin(moon_angle)
     transforms["moon"] = make_transform_matrix([moon_x, moon_y, 0])
 
     animation.add_frame(time=t, transforms=transforms)

--- a/examples/03_animation_basics.py
+++ b/examples/03_animation_basics.py
@@ -67,15 +67,6 @@ planets = [
         "metalness": 0.1,
     },
     {
-        "id": "earth",
-        "radius": 0.3,
-        "color": 0x4488FF,
-        "orbit_radius": 4.5,
-        "period": 5.0,
-        "roughness": 0.5,
-        "metalness": 0.2,
-    },
-    {
         "id": "mars",
         "radius": 0.2,
         "color": 0xFF4422,
@@ -95,9 +86,17 @@ for planet in planets:
         metalness=planet["metalness"],
     )
 
-# Use a group for Earth so the moon inherits Earth's orbit automatically
+# Earth system group — earth and moon are both children.
+# Animating the group moves both; moon only needs its local orbit offset.
 v.add_group("earth_system")
-# Moon as child of earth_system — only needs its local orbit offset
+v.add_sphere(
+    "earth",
+    radius=0.3,
+    color=0x4488FF,
+    roughness=0.5,
+    metalness=0.2,
+    parent="earth_system",
+)
 v.add_sphere(
     "moon",
     radius=0.08,
@@ -128,11 +127,12 @@ for i in range(n_frames):
         y = planet["orbit_radius"] * math.sin(angle)
         transforms[planet["id"]] = make_transform_matrix([x, y, 0])
 
-    # Earth system group follows Earth's orbit
+    # Earth system group — moves earth + moon together
     earth_angle = 2 * math.pi * t / 5.0
     earth_x = 4.5 * math.cos(earth_angle)
     earth_y = 4.5 * math.sin(earth_angle)
     transforms["earth_system"] = make_transform_matrix([earth_x, earth_y, 0])
+    # (earth sphere has no separate transform — it sits at origin within the group)
 
     # Moon only needs its LOCAL orbit offset — the group handles the rest
     moon_angle = 2 * math.pi * t / 0.8  # Fast orbit around earth

--- a/examples/04_flying_teapots.py
+++ b/examples/04_flying_teapots.py
@@ -77,7 +77,8 @@ v.add_box(
     metalness=0.0,
 )
 
-# Add some reference pillars
+# Group reference pillars together
+v.add_group("pillars")
 for i in range(4):
     angle = i * math.pi / 2 + math.pi / 4
     x, y = 8 * math.cos(angle), 8 * math.sin(angle)
@@ -90,6 +91,7 @@ for i in range(4):
         position=[x, y, 3],
         roughness=0.7,
         metalness=0.1,
+        parent="pillars",
     )
 
 # Load teapots via websocket

--- a/examples/14_grouping.py
+++ b/examples/14_grouping.py
@@ -1,0 +1,180 @@
+"""
+Object Grouping Demo
+
+Demonstrates parent-child grouping with a simple robot arm.
+Each joint is a group — animating a joint automatically moves all
+downstream links and the end-effector. This means you only need to
+set local joint angles, not world-space transforms for every piece.
+
+Run: uv run python examples/14_grouping.py
+"""
+
+import math
+
+from threejs_viewer import Animation, viewer
+
+
+def make_transform_matrix(position, rotation_z=0, scale=1.0):
+    """Create a 4x4 transform matrix (column-major for Three.js)."""
+    c, s = math.cos(rotation_z), math.sin(rotation_z)
+    return [
+        scale * c,
+        scale * s,
+        0,
+        0,
+        -scale * s,
+        scale * c,
+        0,
+        0,
+        0,
+        0,
+        scale,
+        0,
+        position[0],
+        position[1],
+        position[2],
+        1,
+    ]
+
+
+v = viewer()
+v.clear()
+v.stop_animation()
+
+# Ground plane
+v.add_box(
+    "ground",
+    width=12,
+    height=12,
+    depth=0.05,
+    color=0x333333,
+    position=[0, 0, -0.025],
+    roughness=0.9,
+    metalness=0.0,
+)
+
+# === Build robot arm using nested groups ===
+#
+# Hierarchy:
+#   base (group at origin)
+#     base_mesh (cylinder)
+#     shoulder (group, offset Z up)
+#       upper_arm (box)
+#       elbow (group, offset along arm)
+#         lower_arm (box)
+#         wrist (group, offset along arm)
+#           hand (sphere)
+
+# Base — rotates around Z
+v.add_group("base")
+v.add_cylinder(
+    "base_mesh",
+    radius_top=0.6,
+    radius_bottom=0.8,
+    height=0.4,
+    color=0x555555,
+    position=[0, 0, 0.2],
+    parent="base",
+    roughness=0.6,
+    metalness=0.3,
+)
+
+# Shoulder joint — positioned on top of base, rotates around Z in XY plane
+v.add_group("shoulder", parent="base", position=[0, 0, 0.4])
+v.add_box(
+    "upper_arm",
+    width=0.3,
+    height=2.0,
+    depth=0.3,
+    color=0xDD6633,
+    position=[0, 1.0, 0],
+    parent="shoulder",
+    roughness=0.4,
+    metalness=0.2,
+)
+v.add_sphere(
+    "shoulder_joint",
+    radius=0.2,
+    color=0x888888,
+    parent="shoulder",
+    roughness=0.3,
+    metalness=0.5,
+)
+
+# Elbow joint — at the end of upper arm
+v.add_group("elbow", parent="shoulder", position=[0, 2.0, 0])
+v.add_box(
+    "lower_arm",
+    width=0.25,
+    height=1.5,
+    depth=0.25,
+    color=0x3366DD,
+    position=[0, 0.75, 0],
+    parent="elbow",
+    roughness=0.4,
+    metalness=0.2,
+)
+v.add_sphere(
+    "elbow_joint",
+    radius=0.17,
+    color=0x888888,
+    parent="elbow",
+    roughness=0.3,
+    metalness=0.5,
+)
+
+# Wrist joint — at the end of lower arm
+v.add_group("wrist", parent="elbow", position=[0, 1.5, 0])
+v.add_sphere(
+    "hand",
+    radius=0.2,
+    color=0x33DD66,
+    parent="wrist",
+    roughness=0.4,
+    metalness=0.3,
+)
+
+# === Animate: only set local joint rotations ===
+duration = 8.0
+fps = 30
+n_frames = int(duration * fps)
+animation = Animation(loop=True)
+
+for i in range(n_frames):
+    t = i / fps
+    transforms = {}
+
+    # Base rotates slowly around Z
+    base_angle = math.sin(t * 0.8) * math.pi / 3
+    transforms["base"] = make_transform_matrix([0, 0, 0], rotation_z=base_angle)
+
+    # Shoulder oscillates
+    shoulder_angle = math.sin(t * 1.2) * math.pi / 4 + math.pi / 6
+    transforms["shoulder"] = make_transform_matrix(
+        [0, 0, 0.4], rotation_z=shoulder_angle
+    )
+
+    # Elbow oscillates opposite to shoulder
+    elbow_angle = math.sin(t * 1.8 + 1.0) * math.pi / 3
+    transforms["elbow"] = make_transform_matrix([0, 2.0, 0], rotation_z=elbow_angle)
+
+    # Wrist wiggles fast
+    wrist_angle = math.sin(t * 3.0) * math.pi / 6
+    transforms["wrist"] = make_transform_matrix([0, 1.5, 0], rotation_z=wrist_angle)
+
+    animation.add_frame(time=t, transforms=transforms)
+
+animation.add_marker(0.0, "Start", color=0x00FF00)
+animation.add_marker(4.0, "Mid-cycle", color=0xFFFF00)
+
+v.load_animation(animation)
+
+print(f"Robot arm demo: {animation.n_frames} frames, {animation.duration:.1f}s")
+print("Only 4 joints are animated — 5 visual meshes follow automatically via grouping.")
+print("Press Ctrl+C to exit.")
+
+try:
+    while True:
+        pass
+except KeyboardInterrupt:
+    v.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.6"
+version = "0.0.7"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "Marker",
 ]
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -120,10 +120,14 @@ class ViewerClient:
             for message in websocket:
                 try:
                     data = json.loads(message)
-                    request_id = data.get("requestId")
-                    if request_id and request_id in self._pending_responses:
-                        self._responses[request_id] = data
-                        self._pending_responses[request_id].set()
+                    msg_type = data.get("type")
+                    if msg_type == "hello":
+                        self._handle_hello(websocket, data)
+                    else:
+                        request_id = data.get("requestId")
+                        if request_id and request_id in self._pending_responses:
+                            self._responses[request_id] = data
+                            self._pending_responses[request_id].set()
                 except json.JSONDecodeError:
                     pass
         except Exception:
@@ -131,6 +135,25 @@ class ViewerClient:
         finally:
             self._ws = None
             self._connected_event.clear()
+
+    def _handle_hello(self, websocket, data):
+        """Handle version handshake from viewer."""
+        from . import __version__
+
+        viewer_version = data.get("viewer_version", "unknown")
+        logger = logging.getLogger(__name__)
+        logger.info("Viewer v%s connected", viewer_version)
+        if viewer_version != __version__:
+            print(
+                f"WARNING: Version mismatch — client v{__version__}, "
+                f"viewer v{viewer_version}. "
+                f"Close the browser tab and re-open viewer.html."
+            )
+        # Send our version back so the viewer can also check
+        try:
+            websocket.send(json.dumps({"type": "hello", "client_version": __version__}))
+        except Exception:
+            pass
 
     def disconnect(self):
         """Disconnect and stop server."""
@@ -162,6 +185,43 @@ class ViewerClient:
 
     # === Object Management ===
 
+    def add_group(
+        self,
+        id: str,
+        parent: Optional[str] = None,
+        position: Optional[List[float]] = None,
+        rotation: Optional[List[float]] = None,
+        scale: Optional[List[float]] = None,
+        visible: bool = True,
+    ) -> None:
+        """
+        Add an empty group to the scene. Objects added with parent=id
+        will inherit this group's transform.
+
+        Args:
+            id: Unique identifier for the group
+            parent: Optional parent group id
+            position: [x, y, z] position
+            rotation: [x, y, z] Euler rotation in radians
+            scale: [x, y, z] scale
+            visible: Initial visibility
+        """
+        msg: dict = {"type": "add_group", "id": id}
+        if parent:
+            msg["parent"] = parent
+        transform = {}
+        if position:
+            transform["position"] = position
+        if rotation:
+            transform["rotation"] = rotation
+        if scale:
+            transform["scale"] = scale
+        if transform:
+            msg["transform"] = transform
+        if not visible:
+            msg["visible"] = False
+        self._send(msg)
+
     def add_box(
         self,
         id: str,
@@ -175,6 +235,7 @@ class ViewerClient:
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """Add a box primitive to the scene."""
         params = {
@@ -188,7 +249,7 @@ class ViewerClient:
             params["roughness"] = roughness
         if metalness is not None:
             params["metalness"] = metalness
-        self._add_primitive(id, "box", params, position, rotation, scale)
+        self._add_primitive(id, "box", params, position, rotation, scale, parent)
 
     def add_sphere(
         self,
@@ -201,6 +262,7 @@ class ViewerClient:
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """Add a sphere primitive to the scene."""
         params = {"radius": radius, "color": color, "opacity": opacity}
@@ -208,7 +270,7 @@ class ViewerClient:
             params["roughness"] = roughness
         if metalness is not None:
             params["metalness"] = metalness
-        self._add_primitive(id, "sphere", params, position, rotation, scale)
+        self._add_primitive(id, "sphere", params, position, rotation, scale, parent)
 
     def add_cylinder(
         self,
@@ -223,6 +285,7 @@ class ViewerClient:
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """Add a cylinder primitive to the scene."""
         params = {
@@ -236,7 +299,7 @@ class ViewerClient:
             params["roughness"] = roughness
         if metalness is not None:
             params["metalness"] = metalness
-        self._add_primitive(id, "cylinder", params, position, rotation, scale)
+        self._add_primitive(id, "cylinder", params, position, rotation, scale, parent)
 
     def add_capsule(
         self,
@@ -250,6 +313,7 @@ class ViewerClient:
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """Add a capsule (pill) primitive to the scene."""
         params = {
@@ -262,7 +326,7 @@ class ViewerClient:
             params["roughness"] = roughness
         if metalness is not None:
             params["metalness"] = metalness
-        self._add_primitive(id, "capsule", params, position, rotation, scale)
+        self._add_primitive(id, "capsule", params, position, rotation, scale, parent)
 
     def add_model(
         self,
@@ -272,6 +336,7 @@ class ViewerClient:
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """
         Add a 3D model to the scene.
@@ -283,6 +348,7 @@ class ViewerClient:
             position: [x, y, z] position
             rotation: [x, y, z] Euler rotation in radians
             scale: [x, y, z] scale
+            parent: Optional parent group id
         """
         transform = {}
         if position:
@@ -292,17 +358,18 @@ class ViewerClient:
         if scale:
             transform["scale"] = scale
 
-        self._send(
-            {
-                "type": "add_object",
-                "id": id,
-                "object": {
-                    "model": url,
-                    "format": format,
-                    "transform": transform if transform else None,
-                },
-            }
-        )
+        msg = {
+            "type": "add_object",
+            "id": id,
+            "object": {
+                "model": url,
+                "format": format,
+                "transform": transform if transform else None,
+            },
+        }
+        if parent:
+            msg["parent"] = parent
+        self._send(msg)
 
     def _send_binary(self, header_dict: dict, payload: bytes) -> None:
         """Send binary data via HTTP blob + JSON notification over WebSocket."""
@@ -320,6 +387,7 @@ class ViewerClient:
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
         matrix: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """
         Add a 3D model to the scene by sending file bytes over WebSocket.
@@ -332,6 +400,7 @@ class ViewerClient:
             rotation: [x, y, z] Euler rotation in radians
             scale: [x, y, z] scale
             matrix: Column-major 4x4 transform matrix (overrides position/rotation/scale)
+            parent: Optional parent group id
         """
         if isinstance(path_or_bytes, bytes):
             mesh_bytes = path_or_bytes
@@ -342,6 +411,8 @@ class ViewerClient:
             mesh_bytes = path.read_bytes()
 
         header = {"type": "add_model_binary", "id": id, "format": format}
+        if parent:
+            header["parent"] = parent
         if matrix:
             header["transform"] = {"matrix": matrix}
         elif position or rotation or scale:
@@ -366,6 +437,7 @@ class ViewerClient:
         cmin: float = None,
         cmax: float = None,
         line_width: int = 2,
+        parent: Optional[str] = None,
     ) -> None:
         """
         Add a polyline to the scene using binary transfer.
@@ -406,17 +478,17 @@ class ViewerClient:
 
         raw_bytes = points.tobytes() + color_bytes
 
-        self._send_binary(
-            {
-                "type": "add_polyline_binary",
-                "id": id,
-                "color": color,
-                "lineWidth": line_width,
-                "hasVertexColors": has_vertex_colors,
-                "numPoints": n_points,
-            },
-            raw_bytes,
-        )
+        header = {
+            "type": "add_polyline_binary",
+            "id": id,
+            "color": color,
+            "lineWidth": line_width,
+            "hasVertexColors": has_vertex_colors,
+            "numPoints": n_points,
+        }
+        if parent:
+            header["parent"] = parent
+        self._send_binary(header, raw_bytes)
 
     def add_mesh(
         self,
@@ -428,6 +500,7 @@ class ViewerClient:
         color: int = 0x7AB8CC,
         metalness: float = 0.1,
         roughness: float = 0.8,
+        parent: Optional[str] = None,
     ) -> None:
         """
         Add a pre-built triangle mesh to the scene.
@@ -457,20 +530,20 @@ class ViewerClient:
             parts.append(colors.tobytes())
         parts.append(indices.tobytes())
 
-        self._send_binary(
-            {
-                "type": "add_mesh_binary",
-                "id": id,
-                "numVertices": num_vertices,
-                "numIndices": len(indices),
-                "hasNormals": has_normals,
-                "hasVertexColors": has_vertex_colors,
-                "color": color,
-                "metalness": metalness,
-                "roughness": roughness,
-            },
-            b"".join(parts),
-        )
+        header = {
+            "type": "add_mesh_binary",
+            "id": id,
+            "numVertices": num_vertices,
+            "numIndices": len(indices),
+            "hasNormals": has_normals,
+            "hasVertexColors": has_vertex_colors,
+            "color": color,
+            "metalness": metalness,
+            "roughness": roughness,
+        }
+        if parent:
+            header["parent"] = parent
+        self._send_binary(header, b"".join(parts))
 
     def add_bead(
         self,
@@ -480,6 +553,7 @@ class ViewerClient:
         height: float,
         colors: np.ndarray = None,
         color: int = 0x7AB8CC,
+        parent: Optional[str] = None,
         **kwargs,
     ) -> None:
         """
@@ -578,6 +652,7 @@ class ViewerClient:
             normals.reshape(-1, 3),
             colors=vertex_colors,
             color=color,
+            parent=parent,
             **kwargs,
         )
 
@@ -652,6 +727,7 @@ class ViewerClient:
         position: Optional[List[float]] = None,
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
+        parent: Optional[str] = None,
     ) -> None:
         """Internal method to add a primitive."""
         transform = {}
@@ -662,17 +738,18 @@ class ViewerClient:
         if scale:
             transform["scale"] = scale
 
-        self._send(
-            {
-                "type": "add_object",
-                "id": id,
-                "object": {
-                    "primitive": primitive,
-                    "params": params,
-                    "transform": transform if transform else None,
-                },
-            }
-        )
+        msg = {
+            "type": "add_object",
+            "id": id,
+            "object": {
+                "primitive": primitive,
+                "params": params,
+                "transform": transform if transform else None,
+            },
+        }
+        if parent:
+            msg["parent"] = parent
+        self._send(msg)
 
     # === Transform Updates ===
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -238,6 +238,9 @@
         import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
         import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 
+        const VIEWER_VERSION = '0.0.7';
+        console.log(`threejs-viewer v${VIEWER_VERSION}`);
+
         // Scene setup
         const scene = new THREE.Scene();
         scene.background = new THREE.Color(0x222222);
@@ -825,8 +828,23 @@
             });
         }
 
+        // Add object to parent or scene
+        function addToParentOrScene(obj, parentId) {
+            if (parentId) {
+                const parent = objects.get(parentId);
+                if (parent) {
+                    parent.add(obj);
+                } else {
+                    console.warn(`Parent '${parentId}' not found, adding to scene`);
+                    scene.add(obj);
+                }
+            } else {
+                scene.add(obj);
+            }
+        }
+
         // Add object to scene
-        async function addObject(id, objData) {
+        async function addObject(id, objData, parentId) {
             let obj;
 
             if (objData.primitive) {
@@ -872,7 +890,7 @@
                     obj.visible = false;
                 }
 
-                scene.add(obj);
+                addToParentOrScene(obj, parentId);
                 objects.set(id, obj);
             }
         }
@@ -936,11 +954,30 @@
             }
         }
 
-        // Delete object
+        // Delete object (and recursively remove children from registry)
         function deleteObject(id) {
             const obj = objects.get(id);
             if (obj) {
-                scene.remove(obj);
+                // Collect all registered child IDs before removal
+                const childIds = [];
+                obj.traverse((child) => {
+                    if (child !== obj && child.userData.id) {
+                        childIds.push(child.userData.id);
+                    }
+                });
+                // Remove children from registry and clean up their mixers
+                for (const childId of childIds) {
+                    objects.delete(childId);
+                    const childMixer = mixers.get(childId);
+                    if (childMixer) {
+                        childMixer.stopAllAction();
+                        mixers.delete(childId);
+                    }
+                }
+                // Remove from parent (scene or group)
+                if (obj.parent) {
+                    obj.parent.remove(obj);
+                }
                 objects.delete(id);
                 // Clean up animation mixer/clips
                 const mixer = mixers.get(id);
@@ -948,12 +985,11 @@
                     mixer.stopAllAction();
                     mixers.delete(id);
                 }
-                // Clean up blob URL if present
-                if (obj.userData.blobUrl) {
-                    URL.revokeObjectURL(obj.userData.blobUrl);
-                }
-                // Dispose geometry and materials
+                // Clean up blob URLs and dispose geometry/materials
                 obj.traverse((child) => {
+                    if (child.userData.blobUrl) {
+                        URL.revokeObjectURL(child.userData.blobUrl);
+                    }
                     if (child.geometry) child.geometry.dispose();
                     if (child.material) {
                         if (Array.isArray(child.material)) {
@@ -1010,6 +1046,7 @@
             ws.onopen = () => {
                 statusEl.textContent = 'Connected';
                 statusEl.className = 'connected';
+                ws.send(JSON.stringify({ type: 'hello', viewer_version: VIEWER_VERSION }));
             };
 
             ws.onclose = () => {
@@ -1032,8 +1069,27 @@
                 }
 
                 switch (data.type) {
+                    case 'hello':
+                        console.log(`Python client v${data.client_version}`);
+                        if (data.client_version !== VIEWER_VERSION) {
+                            console.warn(
+                                `Version mismatch: viewer v${VIEWER_VERSION}, client v${data.client_version}. ` +
+                                `Close this tab and re-open viewer.html to pick up the latest version.`
+                            );
+                        }
+                        break;
+                    case 'add_group': {
+                        const group = new THREE.Group();
+                        group.name = data.id;
+                        group.userData.id = data.id;
+                        if (data.transform) applyTransform(group, data.transform);
+                        if (data.visible === false) group.visible = false;
+                        addToParentOrScene(group, data.parent);
+                        objects.set(data.id, group);
+                        break;
+                    }
                     case 'add_object':
-                        await addObject(data.id, data.object);
+                        await addObject(data.id, data.object, data.parent);
                         break;
                     case 'update_transform':
                         updateTransform(data.id, data.transform);
@@ -1167,7 +1223,7 @@
                                 await addObject(data.id, {
                                     model: blobUrl,
                                     format: data.format || 'stl'
-                                });
+                                }, data.parent);
                                 const obj = objects.get(data.id);
                                 if (obj) {
                                     obj.userData.blobUrl = blobUrl;
@@ -1227,7 +1283,7 @@
                                 line.userData.id = data.id;
                                 line.userData.isPolyline = true;
                                 line.userData.maxInstanceCount = numPoints - 1;
-                                scene.add(line);
+                                addToParentOrScene(line, data.parent);
                                 objects.set(data.id, line);
                             } catch (e) {
                                 console.error(`Error creating polyline via HTTP:`, e);
@@ -1285,7 +1341,7 @@
                                 mesh.userData.id = data.id;
                                 mesh.userData.isMesh = true;
                                 mesh.userData.totalIndexCount = ni;
-                                scene.add(mesh);
+                                addToParentOrScene(mesh, data.parent);
                                 objects.set(data.id, mesh);
                                 console.log(`Created mesh ${data.id}: ${nv} verts, ${(ni / 3)|0} tris`);
                             } catch (e) {

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- **Object grouping** — `add_group(id, parent=...)` creates empty transform nodes; all `add_*` methods accept optional `parent` parameter. Children inherit parent transforms via Three.js scene graph. Deleting a group removes all children.
- **Version handshake** — viewer and Python client exchange versions on WebSocket connect. Mismatches print a warning on both sides, catching stale browser cache immediately.
- Bumps version to 0.0.7

## New example

- `14_grouping.py` — animated robot arm with nested groups (base → shoulder → elbow → wrist)

## Updated examples

- `01_primitives.py` — pillars grouped under common parent
- `03_animation_basics.py` — moon parented to earth_system group
- `04_flying_teapots.py` — reference pillars grouped

## Test plan

- [x] Run `uv run python examples/01_primitives.py` — verify all objects visible including grouped pillars
- [x] Run `uv run python examples/03_animation_basics.py` — verify moon orbits earth locally
- [x] Run `uv run python examples/14_grouping.py` — verify robot arm joints animate children
- [x] Check browser console shows `threejs-viewer v0.0.7` and `Python client v0.0.7`
- [x] Test version mismatch: edit VIEWER_VERSION in viewer.html temporarily, verify warning appears