### PR TITLE
0.0.9: revert primitive Z-up, make GLB Y-up correction opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.0.9
+
+Reverts the 0.0.8 Z-up primitive orientation change and makes GLB/GLTF Y-up correction opt-in.
+
+### Breaking changes
+
+- **Cylinder, cone, capsule are Y-aligned again** — the 0.0.8 change that baked `rotateX(90°)` into these geometries has been reverted. They now use the Three.js default (Y-axis aligned). Any code that added a rotation to compensate for the 0.0.8 Z-up change must remove that compensation. Code that relied on the old Y-up convention (pre-0.0.8) needs no changes.
+- **GLB/GLTF Y-up correction is now opt-in** — `add_model()` and `add_model_binary()` no longer auto-apply `Rx(+90°)` to GLB/GLTF models. Pass `y_up=True` to enable correction for standard Blender/Sketchfab exports. Z-up CAD exports load correctly without this flag.
+
+### New features
+
+- **`y_up=True` on `add_model()` / `add_model_binary()`** — opt-in Y-up→Z-up correction for GLB/GLTF models that follow the glTF spec (Blender, Sketchfab). Default is `False`.
+
 ## 0.0.8
 
 Refactors toolpath coloring and geometry into the `Toolpath` class, adds `wait_for_assets()` for clean script exit, auto-starts animation playback, and fixes Z-up orientation for all built-in primitives and GLTF models.

--- a/examples/01_primitives.py
+++ b/examples/01_primitives.py
@@ -67,6 +67,7 @@ for i, (x, y) in enumerate(pillar_positions):
         height=2.0,
         color=0xB87333,  # Copper color
         position=[x, y, 1.0],
+        rotation=[math.pi / 2, 0, 0],
         roughness=0.3,
         metalness=0.7,
         parent="pillars",

--- a/examples/07_stress_test.py
+++ b/examples/07_stress_test.py
@@ -164,17 +164,17 @@ for i in range(NUM_TEAPOTS):
 
 
 def quaternion_from_direction(direction):
-    """Compute quaternion to rotate Z-axis to given direction."""
+    """Compute quaternion to rotate Y-axis to given direction."""
     d = direction / (np.linalg.norm(direction) + 1e-8)
-    z_axis = np.array([0, 0, 1])
-    dot = np.dot(z_axis, d)
+    y_axis = np.array([0, 1, 0])
+    dot = np.dot(y_axis, d)
 
     if dot > 0.9999:
         return [0, 0, 0, 1]
     if dot < -0.9999:
-        return [1, 0, 0, 0]  # 180° around X
+        return [1, 0, 0, 0]
 
-    axis = np.cross(z_axis, d)
+    axis = np.cross(y_axis, d)
     axis = axis / (np.linalg.norm(axis) + 1e-8)
     angle = np.arccos(np.clip(dot, -1, 1))
     half = angle / 2

--- a/examples/08_glb_models.py
+++ b/examples/08_glb_models.py
@@ -50,7 +50,7 @@ v.clear()
 for name, info in MODELS.items():
     s = info["scale"]
     x, y, z = info["position"]
-    v.add_model_binary(name, model_paths[name], format="glb")
+    v.add_model_binary(name, model_paths[name], format="glb", y_up=True)
     # Column-major 4x4 identity with scale and translation
     v.set_matrix(
         name,

--- a/examples/09_animated_glb.py
+++ b/examples/09_animated_glb.py
@@ -46,8 +46,8 @@ v.clear()
 
 # Load models
 print("Loading models...")
-v.add_model_binary("morphcube", model_paths["morphcube"], format="glb")
-v.add_model_binary("avocado", model_paths["avocado"], format="glb")
+v.add_model_binary("morphcube", model_paths["morphcube"], format="glb", y_up=True)
+v.add_model_binary("avocado", model_paths["avocado"], format="glb", y_up=True)
 
 # Place morphcube at origin, raised slightly
 CUBE_SCALE = 0.5

--- a/examples/10_animation_stress_test.py
+++ b/examples/10_animation_stress_test.py
@@ -82,13 +82,13 @@ def create_tube(t, pos, tangent, tube_radius=0.3, windings=500, z_offset=5.0):
 
 
 def quaternions_from_directions(directions):
-    """Compute quaternions to rotate Z-axis to given directions. Vectorized (N, 3) -> (N, 4)."""
+    """Compute quaternions to rotate Y-axis to given directions. Vectorized (N, 3) -> (N, 4)."""
     norms = np.linalg.norm(directions, axis=1, keepdims=True) + 1e-8
     d = directions / norms
-    z_axis = np.array([0, 0, 1])
-    dots = d @ z_axis  # (N,)
+    y_axis = np.array([0, 1, 0])
+    dots = d @ y_axis  # (N,)
 
-    axes = np.cross(z_axis, d)  # (N, 3)
+    axes = np.cross(y_axis, d)  # (N, 3)
     axis_norms = np.linalg.norm(axes, axis=1, keepdims=True) + 1e-8
     axes = axes / axis_norms
 

--- a/examples/11_toolpath.py
+++ b/examples/11_toolpath.py
@@ -103,9 +103,11 @@ transforms = np.zeros((n_frames, 2, 16), dtype=np.float32)
 # path_tube: identity matrix
 transforms[:, 0, [0, 5, 10, 15]] = 1.0
 
-# Nozzle: identity rotation + translation (cylinder geometry is already Z-aligned)
+# Nozzle: Rot(+90° about X) so Y-up cylinder stands vertically, + per-frame translation
+# Rx(+90°) column-major: [1,0,0,0, 0,0,1,0, 0,-1,0,0, x,y,z,1]
 nz_z = tips[:, 2] + nozzle_height / 2 + nozzle_gap
-transforms[:, 1, [0, 5, 10, 15]] = 1.0
+rx90 = np.array([1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1], dtype=np.float32)
+transforms[:, 1] = rx90
 transforms[:, 1, 12] = tips[:, 0]
 transforms[:, 1, 13] = tips[:, 1]
 transforms[:, 1, 14] = nz_z

--- a/examples/12_transparency.py
+++ b/examples/12_transparency.py
@@ -48,8 +48,8 @@ v.add_box(
     "ground", width=10, height=10, depth=0.02, color=0x333333, position=[0, 0, -0.01]
 )
 
-# Load GLB model — viewer automatically corrects GLTF Y-up to Z-up
-v.add_model_binary("helmet", helmet_path, format="glb", position=[0, 0, 1])
+# Load GLB model — y_up=True corrects glTF Y-up to Z-up viewer convention
+v.add_model_binary("helmet", helmet_path, format="glb", position=[0, 0, 1], y_up=True)
 
 # Primitives with initial opacity
 v.add_sphere(
@@ -72,6 +72,7 @@ v.add_cylinder(
     color=0x44FF44,
     opacity=0.4,
     position=[0, -2, 0.5],
+    rotation=[math.pi / 2, 0, 0],
 )
 
 # One-shot opacity change (before animation takes over)

--- a/examples/13_material_properties.py
+++ b/examples/13_material_properties.py
@@ -6,6 +6,7 @@ to demonstrate PBR material control on primitives. Also includes
 a metallic box and a rough cylinder.
 """
 
+import math
 import time
 
 from threejs_viewer import viewer
@@ -53,6 +54,7 @@ v.add_cylinder(
     roughness=1.0,
     metalness=0.0,
     position=[-2.5, 4.5, 0],
+    rotation=[math.pi / 2, 0, 0],
 )
 
 print("Material properties demo loaded.")

--- a/examples/14_grouping.py
+++ b/examples/14_grouping.py
@@ -65,6 +65,7 @@ v.add_cylinder(
     height=0.4,
     color=0x555555,
     position=[0, 0, 0.2],
+    rotation=[math.pi / 2, 0, 0],
     parent="base",
     roughness=0.6,
     metalness=0.3,

--- a/examples/15_toolpath_interrupted.py
+++ b/examples/15_toolpath_interrupted.py
@@ -130,7 +130,10 @@ frame_nozzle_xyz = merged.points[frame_indices]
 
 transforms = np.zeros((N_FRAMES, 2, 16), dtype=np.float32)
 transforms[:, 0, [0, 5, 10, 15]] = 1.0  # bead: identity
-transforms[:, 1, [0, 5, 10, 15]] = 1.0  # nozzle: identity rotation
+# Nozzle: Rot(+90° about X) so Y-up cylinder stands vertically, + per-frame translation
+# Rx(+90°) column-major: [1,0,0,0, 0,0,1,0, 0,-1,0,0, x,y,z,1]
+rx90 = np.array([1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1], dtype=np.float32)
+transforms[:, 1] = rx90
 transforms[:, 1, 12] = frame_nozzle_xyz[:, 0]
 transforms[:, 1, 13] = frame_nozzle_xyz[:, 1]
 transforms[:, 1, 14] = frame_nozzle_xyz[:, 2] + nozzle_h / 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.8"
+version = "0.0.9"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -29,4 +29,4 @@ __all__ = [
     "Toolpath",
 ]
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -371,6 +371,7 @@ class ViewerClient:
         rotation: Optional[List[float]] = None,
         scale: Optional[List[float]] = None,
         parent: Optional[str] = None,
+        y_up: bool = False,
     ) -> None:
         """
         Add a 3D model to the scene.
@@ -383,6 +384,10 @@ class ViewerClient:
             rotation: [x, y, z] Euler rotation in radians
             scale: [x, y, z] scale
             parent: Optional parent group id
+            y_up: If True, apply Rx(+90°) correction to convert Y-up GLB/GLTF
+                  models to the Z-up viewer convention. Default False (no correction).
+                  Use True for standard Blender/Sketchfab exports; leave False for
+                  Z-up CAD exports.
         """
         transform = {}
         if position:
@@ -392,14 +397,18 @@ class ViewerClient:
         if scale:
             transform["scale"] = scale
 
+        obj_data: dict = {
+            "model": url,
+            "format": format,
+            "transform": transform if transform else None,
+        }
+        if y_up:
+            obj_data["yUp"] = True
+
         msg = {
             "type": "add_object",
             "id": id,
-            "object": {
-                "model": url,
-                "format": format,
-                "transform": transform if transform else None,
-            },
+            "object": obj_data,
         }
         if parent:
             msg["parent"] = parent
@@ -422,6 +431,7 @@ class ViewerClient:
         scale: Optional[List[float]] = None,
         matrix: Optional[List[float]] = None,
         parent: Optional[str] = None,
+        y_up: bool = False,
     ) -> None:
         """
         Add a 3D model to the scene by sending file bytes over WebSocket.
@@ -435,6 +445,10 @@ class ViewerClient:
             scale: [x, y, z] scale
             matrix: Column-major 4x4 transform matrix (overrides position/rotation/scale)
             parent: Optional parent group id
+            y_up: If True, apply Rx(+90°) correction to convert Y-up GLB/GLTF
+                  models to the Z-up viewer convention. Default False (no correction).
+                  Use True for standard Blender/Sketchfab exports; leave False for
+                  Z-up CAD exports.
         """
         if isinstance(path_or_bytes, bytes):
             mesh_bytes = path_or_bytes
@@ -447,6 +461,8 @@ class ViewerClient:
         header = {"type": "add_model_binary", "id": id, "format": format}
         if parent:
             header["parent"] = parent
+        if y_up:
+            header["yUp"] = True
         if matrix:
             header["transform"] = {"matrix": matrix}
         elif position or rotation or scale:

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -238,7 +238,7 @@
         import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
         import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 
-        const VIEWER_VERSION = '0.0.8';
+        const VIEWER_VERSION = '0.0.9';
         console.log(`threejs-viewer v${VIEWER_VERSION}`);
 
         // Scene setup
@@ -762,36 +762,24 @@
             sphere: (params) => new THREE.SphereGeometry(
                 params.radius || 0.5, params.widthSegments || 32, params.heightSegments || 16
             ),
-            cylinder: (params) => {
-                const geo = new THREE.CylinderGeometry(
-                    params.radiusTop || 0.5, params.radiusBottom || 0.5,
-                    params.height || 1, params.radialSegments || 32
-                );
-                geo.rotateX(Math.PI / 2);
-                return geo;
-            },
+            cylinder: (params) => new THREE.CylinderGeometry(
+                params.radiusTop || 0.5, params.radiusBottom || 0.5,
+                params.height || 1, params.radialSegments || 32
+            ),
             plane: (params) => new THREE.PlaneGeometry(
                 params.width || 1, params.height || 1
             ),
-            cone: (params) => {
-                const geo = new THREE.ConeGeometry(
-                    params.radius || 0.5, params.height || 1, params.radialSegments || 32
-                );
-                geo.rotateX(Math.PI / 2);
-                return geo;
-            },
+            cone: (params) => new THREE.ConeGeometry(
+                params.radius || 0.5, params.height || 1, params.radialSegments || 32
+            ),
             torus: (params) => new THREE.TorusGeometry(
                 params.radius || 0.5, params.tube || 0.2,
                 params.radialSegments || 16, params.tubularSegments || 48
             ),
-            capsule: (params) => {
-                const geo = new THREE.CapsuleGeometry(
-                    params.radius || 0.25, params.length || 0.5,
-                    params.capSegments || 8, params.radialSegments || 16
-                );
-                geo.rotateX(Math.PI / 2);
-                return geo;
-            }
+            capsule: (params) => new THREE.CapsuleGeometry(
+                params.radius || 0.25, params.length || 0.5,
+                params.capSegments || 8, params.radialSegments || 16
+            )
         };
 
         // Apply transform to object
@@ -895,7 +883,7 @@
                 }
 
                 try {
-                    const result = await loadModel(loader, objData.model, format);
+                    const result = await loadModel(loader, objData.model, format, objData.yUp === true);
                     obj = result.obj;
                     if (result.animations.length > 0) {
                         // Root the mixer at the GLTF scene so animation tracks
@@ -933,7 +921,7 @@
         }
 
         // Load model helper
-        function loadModel(loader, url, format) {
+        function loadModel(loader, url, format, yUp) {
             return new Promise((resolve, reject) => {
                 loader.load(
                     url,
@@ -941,18 +929,25 @@
                         let obj;
                         let animations = [];
                         if (format === 'gltf' || format === 'glb') {
-                            // GLTF/GLB uses Y-up; wrap in a correction group so
-                            // the model stands upright in the Z-up viewer scene.
-                            // The outer container is user-controlled (set_matrix
-                            // targets it); the inner correction is permanent.
-                            const correction = new THREE.Group();
-                            correction.rotation.x = Math.PI / 2;
-                            correction.add(result.scene);
-                            obj = new THREE.Group();
-                            obj.add(correction);
-                            // Store the GLTF scene root so the AnimationMixer can
-                            // resolve track targets by name inside the hierarchy.
-                            obj.userData.gltfScene = result.scene;
+                            if (yUp) {
+                                // Model uses Y-up (glTF spec default); wrap in a
+                                // correction group to stand it upright in Z-up viewer.
+                                // The outer container is user-controlled (set_matrix
+                                // targets it); the inner correction is permanent.
+                                const correction = new THREE.Group();
+                                correction.rotation.x = Math.PI / 2;
+                                correction.add(result.scene);
+                                obj = new THREE.Group();
+                                obj.add(correction);
+                                // Store the GLTF scene root so the AnimationMixer can
+                                // resolve track targets by name inside the hierarchy.
+                                obj.userData.gltfScene = result.scene;
+                            } else {
+                                // Model is already Z-up (e.g. CAD export); no correction.
+                                obj = new THREE.Group();
+                                obj.add(result.scene);
+                                obj.userData.gltfScene = result.scene;
+                            }
                             animations = result.animations || [];
                         } else if (format === 'dae') {
                             // Create a clean group with only meshes (no lights/cameras from DAE)
@@ -1297,7 +1292,8 @@
                                 console.log(`Loading model ${data.id} (${data.format}) via HTTP`);
                                 await addObject(data.id, {
                                     model: blobUrl,
-                                    format: data.format || 'stl'
+                                    format: data.format || 'stl',
+                                    yUp: data.yUp === true,
                                 }, data.parent);
                                 const obj = objects.get(data.id);
                                 if (obj) {

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -145,6 +145,16 @@ def test_add_model_no_parent(client):
     assert "parent" not in client._messages[0]
 
 
+def test_add_model_y_up_true(client):
+    client.add_model("m", "http://example.com/model.glb", y_up=True)
+    assert client._messages[0]["object"]["yUp"] is True
+
+
+def test_add_model_y_up_default_omitted(client):
+    client.add_model("m", "http://example.com/model.glb")
+    assert "yUp" not in client._messages[0]["object"]
+
+
 # === add_model_binary ===
 
 
@@ -160,6 +170,18 @@ def test_add_model_binary_no_parent(client):
     client.add_model_binary("m", b"\x00" * 10)
     header, _ = client._binary_messages[0]
     assert "parent" not in header
+
+
+def test_add_model_binary_y_up_true(client):
+    client.add_model_binary("m", b"\x00" * 10, y_up=True)
+    header, _ = client._binary_messages[0]
+    assert header["yUp"] is True
+
+
+def test_add_model_binary_y_up_default_omitted(client):
+    client.add_model_binary("m", b"\x00" * 10)
+    header, _ = client._binary_messages[0]
+    assert "yUp" not in header
 
 
 # === add_polyline ===

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.8"
+version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- **Revert cylinder/cone/capsule Z-up**: removes the `rotateX(90°)` baked into geometry in 0.0.8. Primitives are Y-aligned again (Three.js default), matching py-parry3d and the `stick_transform` pattern used in pyflexbot.
- **GLB/GLTF Y-up correction opt-in**: `add_model()` / `add_model_binary()` no longer auto-correct Y-up models. Pass `y_up=True` for standard Blender/Sketchfab/Khronos GLBs; Z-up CAD exports load correctly without it.
- **Examples updated**: static cylinders get explicit `rotation=[pi/2, 0, 0]`; nozzle animation matrices restored; `quaternion_from_direction` reverted to Y-axis; Khronos sample GLBs (08, 09, 12) get `y_up=True`.

## Breaking changes (vs 0.0.8)

- Cylinder, cone, capsule are Y-aligned again — code that added rotations to compensate for 0.0.8 must remove them; code that relied on pre-0.0.8 Y-up convention needs no changes.
- GLB/GLTF no longer auto-corrected — add `y_up=True` for Y-up models.

## Test plan

- [ ] `uv run pytest` — all 91 tests pass
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] Run `01_primitives.py` — pillars stand upright
- [ ] Run `08_glb_models.py` — DamagedHelmet and Avocado correctly oriented
- [ ] Run `11_toolpath.py` — nozzle cylinder vertical above toolpath
- [ ] Run `14_grouping.py` — robot arm base cylinder upright, arm animates correctly