### PR TITLE
0.0.10: opacity on add_mesh, plane_normal on Toolpath.to_mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.10
+
+Adds opacity support to `add_mesh()` and a `plane_normal` parameter to `Toolpath.to_mesh()` for non-horizontal layer planes.
+
+### New features
+
+- **`opacity` parameter on `add_mesh()`** — set initial material opacity (0.0–1.0) at mesh creation time, consistent with `add_primitive()` and `set_opacity()`
+- **`plane_normal` parameter on `Toolpath.to_mesh()`** — the "up" direction for the bead cross-section. Defaults to `[0, 0, 1]` (world Z-up). Pass a transformed normal when slicing on a tilted plane so bead height is perpendicular to the layer surface rather than world-vertical.
+
 ## 0.0.9
 
 Reverts the 0.0.8 Z-up primitive orientation change and makes GLB/GLTF Y-up correction opt-in.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.9"
+version = "0.0.10"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -7,7 +7,7 @@ for f in examples/0{1..9}_*.py examples/1[0-9]_*.py; do
     uv run "$f" &
     pid=$!
     echo "[$i/$total] PID $pid — waiting 5s (press any key to skip)..."
-    read -t 10 -n 1 -s key
+    read -t 20 -n 1 -s key
     if kill -0 $pid 2>/dev/null; then
         echo "[$i/$total] Killing $pid (still running)"
         kill $pid 2>/dev/null

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -29,4 +29,4 @@ __all__ = [
     "Toolpath",
 ]
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -548,6 +548,7 @@ class ViewerClient:
         normals: np.ndarray = None,
         colors: np.ndarray = None,
         color: int = 0x7AB8CC,
+        opacity: float = 1.0,
         metalness: float = 0.1,
         roughness: float = 0.8,
         parent: Optional[str] = None,
@@ -562,6 +563,7 @@ class ViewerClient:
             normals: optional (N, 3) float32 vertex normals
             colors: optional (N, 3) float32 per-vertex RGB colors (0-1)
             color: Material color (hex), ignored when colors is provided
+            opacity: Material opacity (0.0 = invisible, 1.0 = fully opaque)
             metalness: PBR metalness (0-1)
             roughness: PBR roughness (0-1)
         """
@@ -588,6 +590,7 @@ class ViewerClient:
             "hasNormals": has_normals,
             "hasVertexColors": has_vertex_colors,
             "color": color,
+            "opacity": opacity,
             "metalness": metalness,
             "roughness": roughness,
         }

--- a/src/threejs_viewer/toolpath.py
+++ b/src/threejs_viewer/toolpath.py
@@ -375,12 +375,19 @@ class Toolpath:
 
     # ── geometry ──────────────────────────────────────────────────────────────
 
-    def to_mesh(self) -> dict:
+    def to_mesh(self, plane_normal: "np.ndarray | None" = None) -> dict:
         """Build bead mesh geometry.
 
         Generates a 6-vertex bevelled rectangle cross-section extruded along
         the path with analytical normals.  Supports ``draw_range`` for
         progressive reveal animation.
+
+        Args:
+            plane_normal: The "up" direction for the bead cross-section, i.e.
+                the slice-plane normal in viewer space.  Defaults to
+                ``[0, 0, 1]`` (world Z-up).  Pass the transformed plane normal
+                when slicing on a tilted plane so the bead height is
+                perpendicular to the layer surface rather than world-vertical.
 
         Returns:
             Dict with keys ``positions``, ``indices``, ``normals``, ``colors``.
@@ -411,30 +418,41 @@ class Toolpath:
         prof_n = edge_n + np.roll(edge_n, 1, axis=1)  # (N, P, 2)
         prof_n /= np.maximum(np.linalg.norm(prof_n, axis=-1, keepdims=True), 1e-10)
 
-        # Central-difference tangents (XY only, Z-up assumption)
-        tangents = np.empty((N, 2), dtype=np.float32)
-        tangents[0] = points[1, :2] - points[0, :2]
-        tangents[-1] = points[-1, :2] - points[-2, :2]
-        tangents[1:-1] = points[2:, :2] - points[:-2, :2]
+        # Plane normal ("up" direction for cross-section height)
+        if plane_normal is None:
+            up = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+        else:
+            up = np.asarray(plane_normal, dtype=np.float32)
+            up = up / np.maximum(float(np.linalg.norm(up)), 1e-10)
+
+        # Central-difference tangents (3D), projected perpendicular to plane normal
+        tangents = np.empty((N, 3), dtype=np.float32)
+        tangents[0] = points[1] - points[0]
+        tangents[-1] = points[-1] - points[-2]
+        tangents[1:-1] = points[2:] - points[:-2]
+        tangents -= (tangents * up).sum(axis=1, keepdims=True) * up
         t_len = np.linalg.norm(tangents, axis=1, keepdims=True)
         tangents /= np.maximum(t_len, 1e-10)
 
-        # Binormals: tangent × Z = (ty, -tx)
-        binormals = np.column_stack([tangents[:, 1], -tangents[:, 0]])
+        # Binormals: tangent × up  (perpendicular to both, lies in the layer plane)
+        binormals = np.cross(tangents, up).astype(np.float32)  # (N, 3)
+        b_len = np.linalg.norm(binormals, axis=1, keepdims=True)
+        binormals /= np.maximum(b_len, 1e-10)
 
         # Positions: (N, P, 3)
-        positions = np.empty((N, P, 3), dtype=np.float32)
-        positions[:, :, 0] = points[:, 0:1] + pb * binormals[:, 0:1]
-        positions[:, :, 1] = points[:, 1:2] + pb * binormals[:, 1:2]
-        positions[:, :, 2] = points[:, 2:3] + pz
+        positions = (
+            points[:, np.newaxis, :]  # (N, 1, 3)
+            + pb[:, :, np.newaxis] * binormals[:, np.newaxis, :]  # (N, P, 3)
+            + pz[:, :, np.newaxis] * up  # (N, P, 3)
+        )
 
         # Normals: (N, P, 3) — profile normals rotated into world frame
         nb = prof_n[:, :, 0]  # (N, P) binormal component
-        nz = prof_n[:, :, 1]  # (N, P) z component
-        normals = np.empty((N, P, 3), dtype=np.float32)
-        normals[:, :, 0] = nb * binormals[:, 0:1]
-        normals[:, :, 1] = nb * binormals[:, 1:2]
-        normals[:, :, 2] = nz
+        nz = prof_n[:, :, 1]  # (N, P) z (plane-normal) component
+        normals = (
+            nb[:, :, np.newaxis] * binormals[:, np.newaxis, :]  # (N, P, 3)
+            + nz[:, :, np.newaxis] * up  # (N, P, 3)
+        )
 
         # Step-major indices for draw_range reveal along path
         i_range = np.arange(N - 1, dtype=np.uint32)

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -238,7 +238,7 @@
         import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
         import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 
-        const VIEWER_VERSION = '0.0.9';
+        const VIEWER_VERSION = '0.0.10';
         console.log(`threejs-viewer v${VIEWER_VERSION}`);
 
         // Scene setup
@@ -1405,10 +1405,14 @@
                                     geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
                                 }
 
+                                const opacity = data.opacity !== undefined ? data.opacity : 1;
                                 const material = new THREE.MeshStandardMaterial({
                                     color: colors ? 0xffffff : (data.color || 0x7ab8cc),
                                     metalness: data.metalness !== undefined ? data.metalness : 0.1,
                                     roughness: data.roughness !== undefined ? data.roughness : 0.8,
+                                    opacity: opacity,
+                                    transparent: opacity < 1,
+                                    depthWrite: opacity >= 1,
                                     side: THREE.DoubleSide,
                                     vertexColors: !!colors,
                                 });

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -222,6 +222,22 @@ def test_add_mesh_no_parent(client):
     assert "parent" not in header
 
 
+def test_add_mesh_opacity_forwarded(client):
+    pos = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    idx = np.array([0, 1, 2], dtype=np.uint32)
+    client.add_mesh("m", pos, idx, opacity=0.5)
+    header, _ = client._binary_messages[0]
+    assert header["opacity"] == 0.5
+
+
+def test_add_mesh_opacity_default_is_one(client):
+    pos = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    idx = np.array([0, 1, 2], dtype=np.uint32)
+    client.add_mesh("m", pos, idx)
+    header, _ = client._binary_messages[0]
+    assert header["opacity"] == 1.0
+
+
 # === Toolpath.to_mesh + add_mesh ===
 
 

--- a/tests/test_toolpath.py
+++ b/tests/test_toolpath.py
@@ -336,6 +336,40 @@ def test_to_mesh_no_colors_is_none():
     assert mesh["colors"] is None
 
 
+def test_to_mesh_plane_normal_default_matches_z_up():
+    """plane_normal=None (default) produces same result as passing [0,0,1]."""
+    N = 5
+    tp = _simple_tp(N)
+    mesh_default = tp.to_mesh()
+    mesh_explicit = tp.to_mesh(plane_normal=np.array([0.0, 0.0, 1.0]))
+    assert np.allclose(mesh_default["positions"], mesh_explicit["positions"], atol=1e-6)
+    assert np.allclose(mesh_default["normals"], mesh_explicit["normals"], atol=1e-6)
+
+
+def test_to_mesh_plane_normal_y_up():
+    """plane_normal=[0,1,0] produces different geometry than the default Z-up.
+
+    Path along X, plane_normal=Y:
+      Z-up: binormal=[0,-1,0], height along Z → Z spread = bead_height
+      Y-up: binormal=[0,0,1], height along Y → Z spread = bead_width
+
+    So Z spread should be larger with Y-up (bead_width=0.2) than with Z-up
+    (bead_height=0.1).
+    """
+    pts = np.zeros((3, 3), dtype=np.float32)
+    pts[:, 0] = [0.0, 1.0, 2.0]  # path along X, all at Y=Z=0
+    tp = Toolpath.from_points(pts, bead_width=0.2, bead_height=0.1)
+
+    mesh_zup = tp.to_mesh()
+    mesh_yup = tp.to_mesh(plane_normal=np.array([0.0, 1.0, 0.0]))
+
+    # Z-up: height (bead_height=0.1) goes along Z
+    assert abs(np.ptp(mesh_zup["positions"][:, 2]) - 0.1) < 0.01, "Z-up: Z spread ≈ bead_height"
+    # Y-up: width (bead_width=0.2) goes along Z (binormal), height along Y
+    assert abs(np.ptp(mesh_yup["positions"][:, 2]) - 0.2) < 0.01, "Y-up: Z spread ≈ bead_width"
+    assert abs(np.ptp(mesh_yup["positions"][:, 1]) - 0.1) < 0.01, "Y-up: Y spread ≈ bead_height"
+
+
 def test_to_mesh_zero_width_ring_collapsed():
     """W=H=0 ring: all 6 vertices collapse to the path point."""
     pts = np.zeros((4, 3), dtype=np.float32)

--- a/tests/test_toolpath.py
+++ b/tests/test_toolpath.py
@@ -364,10 +364,16 @@ def test_to_mesh_plane_normal_y_up():
     mesh_yup = tp.to_mesh(plane_normal=np.array([0.0, 1.0, 0.0]))
 
     # Z-up: height (bead_height=0.1) goes along Z
-    assert abs(np.ptp(mesh_zup["positions"][:, 2]) - 0.1) < 0.01, "Z-up: Z spread ≈ bead_height"
+    assert abs(np.ptp(mesh_zup["positions"][:, 2]) - 0.1) < 0.01, (
+        "Z-up: Z spread ≈ bead_height"
+    )
     # Y-up: width (bead_width=0.2) goes along Z (binormal), height along Y
-    assert abs(np.ptp(mesh_yup["positions"][:, 2]) - 0.2) < 0.01, "Y-up: Z spread ≈ bead_width"
-    assert abs(np.ptp(mesh_yup["positions"][:, 1]) - 0.1) < 0.01, "Y-up: Y spread ≈ bead_height"
+    assert abs(np.ptp(mesh_yup["positions"][:, 2]) - 0.2) < 0.01, (
+        "Y-up: Z spread ≈ bead_width"
+    )
+    assert abs(np.ptp(mesh_yup["positions"][:, 1]) - 0.1) < 0.01, (
+        "Y-up: Y spread ≈ bead_height"
+    )
 
 
 def test_to_mesh_zero_width_ring_collapsed():

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- **`opacity` parameter on `add_mesh()`** — set initial material opacity (0.0–1.0) at mesh creation time, consistent with `add_primitive()` and `set_opacity()`
- **`plane_normal` parameter on `Toolpath.to_mesh()`** — the "up" direction for the bead cross-section (default `[0,0,1]`); enables correct bead geometry on tilted layer planes so bead height is perpendicular to the layer surface rather than world-vertical
- `run_examples.sh`: increase per-example wait from 10s to 20s

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — passes
- [x] `uv run pytest -v` — 99 tests pass (added 4 new unit tests covering `opacity` and `plane_normal`)