### PR TITLE
Add clip_times binary channel support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,14 @@ Binary channel API:
 - `animation.set_frame_times(times)` — numpy array of frame times
 - `animation.set_transform_data(object_ids, data)` — (n_frames, n_objects, 16) float32
 - `animation.set_draw_range_data(object_ids, data)` — (n_frames, n_objects) float32
+- `animation.set_clip_time_data(object_ids, data)` — (n_frames, n_objects) float32
 - `animation.add_channel(name, ids, data, dtype, stride, metadata)` — generic channel
 
-Supported channel types: `transforms` (stride=16), `draw_ranges`, `colors`, `visibility`, `opacity`
+Supported channel types: `transforms` (stride=16), `draw_ranges`, `colors`, `visibility`, `opacity`, `clip_times`
 Supported dtypes: `float32`, `uint32`, `uint8`
 Indexed colors: `dtype="uint8"` + `metadata={"colormap": [0x44AA44, 0xFF3333]}`
 
-Binary channels and Frame-based JSON can coexist (e.g. binary transforms + JSON clip_times). A binary channel supersedes the same-named Frame field.
+Binary channels and Frame-based JSON can coexist. A binary channel supersedes the same-named Frame field.
 
 ### Examples
 - `01_primitives.py` - Basic shapes with colors and positions

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -123,10 +123,10 @@ animation.add_channel("visibility", ids, data, dtype="uint8")
 ```
 
 The two approaches can be mixed: binary channels supersede Frame fields with the
-same name, while Frame-only fields (like `clip_times`) are sent as sparse JSON.
+same name.
 
 Supported channel types: `transforms` (stride=16), `draw_ranges`, `colors`,
-`visibility`, `opacity`. Supported dtypes: `float32`, `uint32`, `uint8`.
+`visibility`, `opacity`, `clip_times`. Supported dtypes: `float32`, `uint32`, `uint8`.
 
 ### Embedded GLTF Animations
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ animation.set_transform_data(object_ids, transform_array)
 # Draw ranges: (n_frames, n_objects) float32
 animation.set_draw_range_data(object_ids, draw_range_array)
 
+# Clip times for embedded GLTF animations: (n_frames, n_objects) float32
+animation.set_clip_time_data(object_ids, clip_time_array)
+
 # Colors with indexed colormap: (n_frames, n_objects) uint8
 animation.add_channel("colors", object_ids, color_indices, dtype="uint8",
                        metadata={"colormap": [0x44AA44, 0xFF3333]})
@@ -137,7 +140,7 @@ animation.add_channel("visibility", object_ids, vis_data, dtype="uint8")
 client.load_animation(animation)
 ```
 
-Binary channels and Frame-based JSON can be mixed (e.g. binary transforms + JSON `clip_times`).
+Binary channels and Frame-based JSON can be mixed. A binary channel supersedes the same-named Frame field.
 
 ### GLB Models with Embedded Animations
 

--- a/src/threejs_viewer/animation.py
+++ b/src/threejs_viewer/animation.py
@@ -182,6 +182,10 @@ class Animation:
         """Convenience: add a 'draw_ranges' channel."""
         self.add_channel("draw_ranges", object_ids, data, dtype="float32", stride=1)
 
+    def set_clip_time_data(self, object_ids: list[str], data: np.ndarray) -> None:
+        """Convenience: add a 'clip_times' channel."""
+        self.add_channel("clip_times", object_ids, data, dtype="float32", stride=1)
+
     def add_marker(self, time: float, label: str, color: int = 0xFF0000) -> None:
         """Add a labeled marker on the timeline."""
         self.markers.append(Marker(time=time, label=label, color=color))

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -838,7 +838,7 @@ class ViewerClient:
                 meta["visibility"] = frame.visibility
             if frame.opacity and "opacity" not in binary_channel_names:
                 meta["opacity"] = frame.opacity
-            if frame.clip_times:
+            if frame.clip_times and "clip_times" not in binary_channel_names:
                 meta["clip_times"] = frame.clip_times
             if frame.draw_ranges and "draw_ranges" not in binary_channel_names:
                 meta["draw_ranges"] = frame.draw_ranges
@@ -856,7 +856,7 @@ class ViewerClient:
             logger.info(
                 "Animation has %d JSON per-frame entries in frames_meta. "
                 "Consider using animation.add_channel() for colors/visibility/"
-                "opacity/draw_ranges for much faster serialization.",
+                "opacity/draw_ranges/clip_times for much faster serialization.",
                 meta_entry_count,
             )
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -498,6 +498,13 @@
                     if (obj) applyOpacity(obj, val);
                 }
             },
+
+            clip_times(ch, refs, base) {
+                const nObj = ch.ids.length;
+                for (let i = 0; i < nObj; i++) {
+                    setClipTime(ch.ids[i], ch.data[base + i]);
+                }
+            },
         };
 
         function applyFrame(frameIndex) {

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -117,6 +117,21 @@ def test_set_draw_range_data():
     assert animation._channels[0].stride == 1
 
 
+def test_set_clip_time_data():
+    """Test set_clip_time_data convenience wrapper creates a clip_times channel."""
+    animation = Animation(loop=True)
+    animation.set_frame_times(np.linspace(0, 5, 50))
+
+    clip_times = np.linspace(0, 2, 50).reshape(50, 1).astype(np.float32)
+    clip_times = np.column_stack([clip_times, clip_times * 0.5])
+    animation.set_clip_time_data(["model_a", "model_b"], clip_times)
+
+    assert len(animation._channels) == 1
+    assert animation._channels[0].name == "clip_times"
+    assert animation._channels[0].dtype == "float32"
+    assert animation._channels[0].stride == 1
+
+
 def test_add_channel_generic():
     """Test add_channel with custom channel types."""
     animation = Animation(loop=True)
@@ -211,7 +226,7 @@ def test_binary_channels_with_frame_objects():
     """Test that binary channels and Frame objects can coexist (mixed mode)."""
     animation = Animation(loop=True)
 
-    # Frames with clip_times (no binary channel for this)
+    # Frames with clip_times as JSON
     for i in range(5):
         animation.add_frame(
             time=i / 30.0,


### PR DESCRIPTION
## Summary
- **viewer.html**: Add `clip_times` handler to `CHANNEL_APPLY` so binary clip_times channels are applied during animation playback
- **animation.py**: Add `set_clip_time_data()` convenience method (mirrors `set_draw_range_data()`)
- **client.py**: Skip JSON `clip_times` in `frames_meta` when a binary channel exists (same as other channel types), update suggestion message

## Motivation
`clip_times` (for driving embedded GLTF animations) was the only animation field without binary channel support. For animations with many frames, this meant sending per-frame JSON metadata instead of a single efficient binary transfer via the HTTP sidecar.

## Changes
| File | Change |
|------|--------|
| `viewer.html` | Added `clip_times` to `CHANNEL_APPLY` — calls `setClipTime(id, value)` per object |
| `animation.py` | Added `set_clip_time_data(object_ids, data)` convenience wrapper |
| `client.py` | `clip_times` now respects binary channel override; updated warning message |
| `test_animation.py` | Added `test_set_clip_time_data` test |
| `CLAUDE.md`, `DESIGN.md`, `README.md` | Updated docs to list `clip_times` as a supported channel type |

## Test plan
- [x] `test_set_clip_time_data` — verifies convenience method creates correct channel
- [x] All 100 existing tests pass
- [x] Lint passes