### PR TITLE
Auto-open viewer in browser on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Auto-open the viewer in the default browser when no existing tab connects.
 
 ### New features
 
-- **Auto-open browser** — `connect()` now waits 1 second for an existing browser tab to reconnect; if none does, it automatically opens the viewer in the default browser via `webbrowser.open()`. Controlled by the new `open_browser` parameter (default `True`). Set `open_browser=False` to disable (e.g. headless CI, remote servers). Gracefully falls back to printing the path if the browser cannot be opened.
+- **Auto-open browser** — `connect()` now waits 2.5 seconds for an existing browser tab to reconnect; if none does, it automatically opens the viewer in the default browser via `webbrowser.open()`. Controlled by the new `open_browser` parameter on `ViewerClient` constructor (default `True`). Set `open_browser=False` to disable (e.g. headless CI, remote servers). Also available via the `viewer()` convenience function. Gracefully falls back to printing the path if the browser cannot be opened.
 
 ## 0.0.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.13
+
+Auto-open the viewer in the default browser when no existing tab connects.
+
+### New features
+
+- **Auto-open browser** — `connect()` now waits 1 second for an existing browser tab to reconnect; if none does, it automatically opens the viewer in the default browser via `webbrowser.open()`. Controlled by the new `open_browser` parameter (default `True`). Set `open_browser=False` to disable (e.g. headless CI, remote servers). Gracefully falls back to printing the path if the browser cannot be opened.
+
 ## 0.0.12
 
 Interactive clipping plane with slab mode, orthographic camera, and slice view for inspecting toolpath layers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Auto-open the viewer in the default browser when no existing tab connects.
 
 ### New features
 
-- **Auto-open browser** — `connect()` now waits 2.5 seconds for an existing browser tab to reconnect; if none does, it automatically opens the viewer in the default browser via `webbrowser.open()`. Controlled by the new `open_browser` parameter on `ViewerClient` constructor (default `True`). Set `open_browser=False` to disable (e.g. headless CI, remote servers). Also available via the `viewer()` convenience function. Gracefully falls back to printing the path if the browser cannot be opened.
+- **Auto-open browser** — `connect()` now waits 2.5 seconds for an existing browser tab to reconnect; if none does, it automatically opens the viewer in the default browser via `webbrowser.open()`. Controlled by the new `open_browser` parameter on `ViewerClient` constructor (default `True`). Set `open_browser=False` to disable (e.g. headless CI, remote servers). Also available via the `viewer()` convenience function. Gracefully falls back to printing the full viewer URL if the browser cannot be opened.
 
 ## 0.0.12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ uv run pytest -v
 # Run linting
 uv run ruff check . && uv run ruff format --check .
 
-# Open viewer in browser (get path with)
+# Open viewer manually (browser auto-opens by default)
 uv run python -m threejs_viewer path
 
 # Run examples

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -81,7 +81,7 @@ client.add_sphere("ball", radius=0.5, position=[1, 0, 0])
 client.add_model_binary("robot", "robot.stl")
 
 # Update transforms
-client.set_transforms({"ball": matrix_4x4})
+client.set_matrix("ball", matrix_4x4)
 
 # Load animation
 client.load_animation(animation)
@@ -254,7 +254,7 @@ with viewer() as v:
 ```python
 from threejs_viewer import ViewerClient
 
-client = ViewerClient()
+client = ViewerClient()  # open_browser=False for headless/remote
 client.connect()
 
 # Keep running, make calls interactively
@@ -262,6 +262,8 @@ client.add_box("cube", width=1)
 ```
 
 ### Finding the Viewer
+
+The browser opens automatically by default. To open manually or find the path:
 
 ```bash
 # CLI commands

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -254,7 +254,7 @@ with viewer() as v:
 ```python
 from threejs_viewer import ViewerClient
 
-client = ViewerClient()  # open_browser=False for headless/remote
+client = ViewerClient(open_browser=False)  # disable auto-open for headless/remote
 client.connect()
 
 # Keep running, make calls interactively

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ v.add_box("ground", width=5, height=5, depth=0.1, color=0x444444)
 input("Press Enter to exit")
 ```
 
-Open the viewer in your browser:
+The viewer opens automatically in your default browser. To open it manually:
 
 ```bash
 threejs-viewer open

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.12"
+version = "0.0.13"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -29,4 +29,4 @@ __all__ = [
     "Toolpath",
 ]
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -89,7 +89,7 @@ class ViewerClient:
         # one.  The browser's reconnect cycle (500ms onclose + up to 1000ms
         # probe retry) means worst-case ~1.5s, so 2.5s covers foreground tabs
         # with margin.
-        if self.open_browser:
+        if self.open_browser and timeout > 0:
             grace = min(2.5, timeout)
             if not self._connected_event.wait(timeout=grace):
                 self._open_viewer_in_browser()
@@ -101,6 +101,7 @@ class ViewerClient:
             self._connected_event.wait(timeout=remaining)
 
         if not self._connected_event.is_set():
+            self.disconnect()
             raise TimeoutError(
                 f"No viewer connected within {timeout}s. "
                 f"Open the HTML viewer in a browser: {self.viewer_path}"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -72,6 +72,8 @@ class ViewerClient:
         Args:
             timeout: Maximum seconds to wait for a browser connection.
         """
+        if timeout < 0:
+            raise ValueError("timeout must be non-negative")
         # Start HTTP server for fast binary transfers
         self._http_port = self.port + 1
         http_server = HTTPServer((self.host, self._http_port), _BlobHandler)

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -94,7 +94,7 @@ class ViewerClient:
             if not self._connected_event.wait(timeout=grace):
                 self._open_viewer_in_browser()
         else:
-            print(f"Open viewer: {self.viewer_path}")
+            print(f"Open viewer: {self.viewer_url}")
 
         remaining = deadline - time.monotonic()
         if remaining > 0:
@@ -104,25 +104,30 @@ class ViewerClient:
             self.disconnect()
             raise TimeoutError(
                 f"No viewer connected within {timeout}s. "
-                f"Open the HTML viewer in a browser: {self.viewer_path}"
+                f"Open the HTML viewer in a browser: {self.viewer_url}"
             )
         print("Viewer connected!")
         return self
 
     def _open_viewer_in_browser(self):
         """Open the viewer HTML in the default browser."""
-        url = self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
+        url = self.viewer_url
         try:
             print("No existing viewer found, opening browser...")
             if not webbrowser.open(url):
-                print(f"Could not open browser. Open manually: {self.viewer_path}")
+                print(f"Could not open browser. Open manually: {url}")
         except (OSError, webbrowser.Error):
-            print(f"Could not open browser. Open manually: {self.viewer_path}")
+            print(f"Could not open browser. Open manually: {url}")
 
     @property
     def viewer_path(self) -> Path:
         """Path to the viewer.html file."""
         return Path(__file__).parent / "viewer.html"
+
+    @property
+    def viewer_url(self) -> str:
+        """Full file:// URL to the viewer, including ws_port query param."""
+        return self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
 
     def _run_server(self):
         """Run the WebSocket server in a background thread."""

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -238,6 +238,7 @@ class ViewerClient:
         """Disconnect and stop server."""
         if self._http_server:
             self._http_server.shutdown()
+            self._http_server.server_close()
             self._http_server = None
         if self._server:
             self._server.shutdown()

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -10,6 +10,7 @@ import logging
 import threading
 import time
 import uuid
+import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -44,9 +45,15 @@ class ViewerClient:
     Runs a WebSocket server that the browser viewer connects to.
     """
 
-    def __init__(self, host: str = "localhost", port: int = 5666):
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 5666,
+        open_browser: bool = True,
+    ):
         self.host = host
         self.port = port
+        self.open_browser = open_browser
         self._ws = None
         self._server = None
         self._server_thread = None
@@ -59,13 +66,11 @@ class ViewerClient:
         self._http_server = None
         self._blob_store: Dict[str, bytes] = {}
 
-    def connect(self, timeout: float = 30.0, open_browser: bool = True):
+    def connect(self, timeout: float = 30.0):
         """Start WebSocket server and wait for browser to connect.
 
         Args:
             timeout: Maximum seconds to wait for a browser connection.
-            open_browser: If True (default), automatically open the viewer in
-                the default browser if no existing tab connects within 1 second.
         """
         # Start HTTP server for fast binary transfers
         self._http_port = self.port + 1
@@ -80,19 +85,16 @@ class ViewerClient:
         print(f"Waiting for viewer to connect on ws://{self.host}:{self.port} ...")
         deadline = time.monotonic() + timeout
 
-        # Give an existing browser tab a few seconds to reconnect before
-        # opening a new one.
-        if open_browser:
-            grace = min(1.0, timeout)
+        # Give an existing browser tab time to reconnect before opening a new
+        # one.  The browser's reconnect cycle (500ms onclose + up to 1000ms
+        # probe retry) means worst-case ~1.5s, so 2.5s covers foreground tabs
+        # with margin.
+        if self.open_browser:
+            grace = min(2.5, timeout)
             if not self._connected_event.wait(timeout=grace):
-                try:
-                    import webbrowser
-
-                    url = f"file://{self.viewer_path.resolve()}"
-                    print(f"No viewer found, opening {url}")
-                    webbrowser.open(url)
-                except Exception:
-                    print(f"Could not open browser. Open manually: {self.viewer_path}")
+                self._open_viewer_in_browser()
+        else:
+            print(f"Open viewer: {self.viewer_path}")
 
         remaining = deadline - time.monotonic()
         if remaining > 0:
@@ -100,10 +102,21 @@ class ViewerClient:
 
         if not self._connected_event.is_set():
             raise TimeoutError(
-                f"No viewer connected within {timeout}s. Open the HTML viewer in a browser."
+                f"No viewer connected within {timeout}s. "
+                f"Open the HTML viewer in a browser: {self.viewer_path}"
             )
         print("Viewer connected!")
         return self
+
+    def _open_viewer_in_browser(self):
+        """Open the viewer HTML in the default browser."""
+        url = self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
+        try:
+            print("No existing viewer found, opening browser...")
+            if not webbrowser.open(url):
+                print(f"Could not open browser. Open manually: {self.viewer_path}")
+        except (OSError, webbrowser.Error):
+            print(f"Could not open browser. Open manually: {self.viewer_path}")
 
     @property
     def viewer_path(self) -> Path:
@@ -1063,6 +1076,8 @@ class ViewerClient:
         return response.get("tree", {})
 
 
-def viewer(host: str = "localhost", port: int = 5666) -> ViewerClient:
+def viewer(
+    host: str = "localhost", port: int = 5666, open_browser: bool = True
+) -> ViewerClient:
     """Create and connect a viewer client (starts WebSocket server)."""
-    return ViewerClient(host, port).connect()
+    return ViewerClient(host, port, open_browser=open_browser).connect()

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -8,6 +8,7 @@ Runs a WebSocket server that the browser connects to directly.
 import json
 import logging
 import threading
+import time
 import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -58,8 +59,14 @@ class ViewerClient:
         self._http_server = None
         self._blob_store: Dict[str, bytes] = {}
 
-    def connect(self, timeout: float = 30.0):
-        """Start WebSocket server and wait for browser to connect."""
+    def connect(self, timeout: float = 30.0, open_browser: bool = True):
+        """Start WebSocket server and wait for browser to connect.
+
+        Args:
+            timeout: Maximum seconds to wait for a browser connection.
+            open_browser: If True (default), automatically open the viewer in
+                the default browser if no existing tab connects within 1 second.
+        """
         # Start HTTP server for fast binary transfers
         self._http_port = self.port + 1
         http_server = HTTPServer((self.host, self._http_port), _BlobHandler)
@@ -71,8 +78,27 @@ class ViewerClient:
         self._server_thread.start()
 
         print(f"Waiting for viewer to connect on ws://{self.host}:{self.port} ...")
-        print(f"Open viewer: {self.viewer_path}")
-        if not self._connected_event.wait(timeout=timeout):
+        deadline = time.monotonic() + timeout
+
+        # Give an existing browser tab a few seconds to reconnect before
+        # opening a new one.
+        if open_browser:
+            grace = min(1.0, timeout)
+            if not self._connected_event.wait(timeout=grace):
+                try:
+                    import webbrowser
+
+                    url = f"file://{self.viewer_path.resolve()}"
+                    print(f"No viewer found, opening {url}")
+                    webbrowser.open(url)
+                except Exception:
+                    print(f"Could not open browser. Open manually: {self.viewer_path}")
+
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            self._connected_event.wait(timeout=remaining)
+
+        if not self._connected_event.is_set():
             raise TimeoutError(
                 f"No viewer connected within {timeout}s. Open the HTML viewer in a browser."
             )

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -465,7 +465,7 @@
         import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
         import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
-        const VIEWER_VERSION = '0.0.12';
+        const VIEWER_VERSION = '0.0.13';
         console.log(`threejs-viewer v${VIEWER_VERSION}`);
 
         // Scene setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def _free_port():
 def viewer_client():
     """Start a ViewerClient on a random port (does not wait for browser)."""
     port = _free_port()
-    client = ViewerClient(port=port)
+    client = ViewerClient(port=port, open_browser=False)
 
     # Start the server in the background without blocking for a browser connection
     client._http_port = port + 1

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,115 @@
+"""Tests for ViewerClient.connect() auto-open browser behavior."""
+
+import threading
+import time
+from unittest.mock import patch
+
+from threejs_viewer import ViewerClient
+
+# Use high ports to avoid conflicts; each test gets its own port range.
+_PORT_BASE = 15660
+
+
+def _unique_port(offset):
+    return _PORT_BASE + offset * 2  # *2 because HTTP sidecar uses port+1
+
+
+def _connect_and_catch(client, timeout):
+    """Call connect() and return None on success, the exception on failure."""
+    try:
+        client.connect(timeout=timeout)
+        return None
+    except TimeoutError as e:
+        return e
+    except OSError as e:
+        return e
+
+
+def test_open_browser_false_never_calls_webbrowser():
+    """open_browser=False should never invoke webbrowser.open."""
+    client = ViewerClient(port=_unique_port(0), open_browser=False)
+    with patch("threejs_viewer.client.webbrowser.open") as mock_open:
+        err = _connect_and_catch(client, timeout=0.2)
+    mock_open.assert_not_called()
+    assert isinstance(err, TimeoutError)
+
+
+def test_open_browser_true_calls_webbrowser_after_grace():
+    """open_browser=True should call webbrowser.open when no tab connects."""
+    client = ViewerClient(port=_unique_port(1), open_browser=True)
+    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
+        err = _connect_and_catch(client, timeout=3.5)
+    mock_open.assert_called_once()
+    assert isinstance(err, TimeoutError)
+
+
+def test_open_browser_url_contains_ws_port():
+    """Opened URL should contain ws_port query parameter matching the port."""
+    port = _unique_port(2)
+    client = ViewerClient(port=port, open_browser=True)
+    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
+        _connect_and_catch(client, timeout=3.5)
+    url = mock_open.call_args[0][0]
+    assert f"?ws_port={port}" in url
+
+
+def test_open_browser_url_is_valid_file_uri():
+    """Opened URL should be a valid file:// URI via Path.as_uri()."""
+    client = ViewerClient(port=_unique_port(3), open_browser=True)
+    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
+        _connect_and_catch(client, timeout=3.5)
+    url = mock_open.call_args[0][0]
+    assert url.startswith("file:///")
+    assert "viewer.html" in url
+
+
+def test_open_browser_skipped_when_tab_reconnects_during_grace():
+    """If a connection arrives during grace period, browser should not open."""
+    client = ViewerClient(port=_unique_port(4), open_browser=True)
+
+    def simulate_reconnect():
+        """Simulate a browser tab connecting after a short delay."""
+        time.sleep(0.5)
+        client._connected_event.set()
+
+    t = threading.Thread(target=simulate_reconnect, daemon=True)
+    t.start()
+
+    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
+        client.connect(timeout=5.0)
+    mock_open.assert_not_called()
+    client.disconnect()
+    t.join(timeout=1)
+
+
+def test_timeout_zero_does_not_open_browser():
+    """timeout=0 should not attempt to open browser (no time to connect)."""
+    client = ViewerClient(port=_unique_port(5), open_browser=True)
+    with patch("threejs_viewer.client.webbrowser.open") as mock_open:
+        err = _connect_and_catch(client, timeout=0)
+    mock_open.assert_not_called()
+    assert isinstance(err, TimeoutError)
+
+
+def test_timeout_cleans_up_servers():
+    """On timeout, servers should be shut down so the port is released."""
+    client = ViewerClient(port=_unique_port(6), open_browser=False)
+    err = _connect_and_catch(client, timeout=0.2)
+    assert isinstance(err, TimeoutError)
+    assert client._http_server is None
+    assert client._server is None
+
+
+def test_timeout_respects_deadline():
+    """Total wait should not significantly exceed the requested timeout."""
+    client = ViewerClient(port=_unique_port(7), open_browser=False)
+    start = time.monotonic()
+    _connect_and_catch(client, timeout=0.5)
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.5  # generous margin, but should be ~0.5s
+
+
+def test_constructor_open_browser_default():
+    """open_browser should default to True."""
+    client = ViewerClient()
+    assert client.open_browser is True

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -4,14 +4,9 @@ import threading
 import time
 from unittest.mock import patch
 
+from conftest import _free_port
+
 from threejs_viewer import ViewerClient
-
-# Use high ports to avoid conflicts; each test gets its own port range.
-_PORT_BASE = 15660
-
-
-def _unique_port(offset):
-    return _PORT_BASE + offset * 2  # *2 because HTTP sidecar uses port+1
 
 
 def _connect_and_catch(client, timeout):
@@ -27,7 +22,7 @@ def _connect_and_catch(client, timeout):
 
 def test_open_browser_false_never_calls_webbrowser():
     """open_browser=False should never invoke webbrowser.open."""
-    client = ViewerClient(port=_unique_port(0), open_browser=False)
+    client = ViewerClient(port=_free_port(), open_browser=False)
     with patch("threejs_viewer.client.webbrowser.open") as mock_open:
         err = _connect_and_catch(client, timeout=0.2)
     mock_open.assert_not_called()
@@ -36,7 +31,7 @@ def test_open_browser_false_never_calls_webbrowser():
 
 def test_open_browser_true_calls_open_method():
     """open_browser=True should call _open_viewer_in_browser when no tab connects."""
-    client = ViewerClient(port=_unique_port(1), open_browser=True)
+    client = ViewerClient(port=_free_port(), open_browser=True)
     with patch.object(client, "_open_viewer_in_browser") as mock_open:
         err = _connect_and_catch(client, timeout=0.5)
     mock_open.assert_called_once()
@@ -45,7 +40,7 @@ def test_open_browser_true_calls_open_method():
 
 def test_open_browser_url_contains_ws_port():
     """Opened URL should contain ws_port query parameter matching the port."""
-    port = _unique_port(2)
+    port = _free_port()
     client = ViewerClient(port=port, open_browser=True)
     with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_wb:
         _connect_and_catch(client, timeout=0.5)
@@ -56,7 +51,7 @@ def test_open_browser_url_contains_ws_port():
 
 def test_open_browser_url_is_valid_file_uri():
     """Opened URL should be a valid file:// URI via Path.as_uri()."""
-    client = ViewerClient(port=_unique_port(3), open_browser=True)
+    client = ViewerClient(port=_free_port(), open_browser=True)
     with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_wb:
         _connect_and_catch(client, timeout=0.5)
     url = mock_wb.call_args[0][0]
@@ -66,7 +61,7 @@ def test_open_browser_url_is_valid_file_uri():
 
 def test_open_browser_skipped_when_tab_reconnects_during_grace():
     """If a connection arrives during grace period, browser should not open."""
-    client = ViewerClient(port=_unique_port(4), open_browser=True)
+    client = ViewerClient(port=_free_port(), open_browser=True)
 
     def simulate_reconnect():
         time.sleep(0.3)
@@ -84,7 +79,7 @@ def test_open_browser_skipped_when_tab_reconnects_during_grace():
 
 def test_timeout_zero_does_not_open_browser():
     """timeout=0 should not attempt to open browser (no time to connect)."""
-    client = ViewerClient(port=_unique_port(5), open_browser=True)
+    client = ViewerClient(port=_free_port(), open_browser=True)
     with patch.object(client, "_open_viewer_in_browser") as mock_open:
         err = _connect_and_catch(client, timeout=0)
     mock_open.assert_not_called()
@@ -93,7 +88,7 @@ def test_timeout_zero_does_not_open_browser():
 
 def test_timeout_cleans_up_servers():
     """On timeout, servers should be shut down so the port is released."""
-    client = ViewerClient(port=_unique_port(6), open_browser=False)
+    client = ViewerClient(port=_free_port(), open_browser=False)
     err = _connect_and_catch(client, timeout=0.2)
     assert isinstance(err, TimeoutError)
     assert client._http_server is None
@@ -102,7 +97,7 @@ def test_timeout_cleans_up_servers():
 
 def test_timeout_respects_deadline():
     """Total wait should not significantly exceed the requested timeout."""
-    client = ViewerClient(port=_unique_port(7), open_browser=False)
+    client = ViewerClient(port=_free_port(), open_browser=False)
     start = time.monotonic()
     _connect_and_catch(client, timeout=0.3)
     elapsed = time.monotonic() - start

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -34,11 +34,11 @@ def test_open_browser_false_never_calls_webbrowser():
     assert isinstance(err, TimeoutError)
 
 
-def test_open_browser_true_calls_webbrowser_after_grace():
-    """open_browser=True should call webbrowser.open when no tab connects."""
+def test_open_browser_true_calls_open_method():
+    """open_browser=True should call _open_viewer_in_browser when no tab connects."""
     client = ViewerClient(port=_unique_port(1), open_browser=True)
-    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
-        err = _connect_and_catch(client, timeout=3.5)
+    with patch.object(client, "_open_viewer_in_browser") as mock_open:
+        err = _connect_and_catch(client, timeout=0.5)
     mock_open.assert_called_once()
     assert isinstance(err, TimeoutError)
 
@@ -47,18 +47,19 @@ def test_open_browser_url_contains_ws_port():
     """Opened URL should contain ws_port query parameter matching the port."""
     port = _unique_port(2)
     client = ViewerClient(port=port, open_browser=True)
-    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
-        _connect_and_catch(client, timeout=3.5)
-    url = mock_open.call_args[0][0]
+    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_wb:
+        _connect_and_catch(client, timeout=0.5)
+    mock_wb.assert_called_once()
+    url = mock_wb.call_args[0][0]
     assert f"?ws_port={port}" in url
 
 
 def test_open_browser_url_is_valid_file_uri():
     """Opened URL should be a valid file:// URI via Path.as_uri()."""
     client = ViewerClient(port=_unique_port(3), open_browser=True)
-    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
-        _connect_and_catch(client, timeout=3.5)
-    url = mock_open.call_args[0][0]
+    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_wb:
+        _connect_and_catch(client, timeout=0.5)
+    url = mock_wb.call_args[0][0]
     assert url.startswith("file:///")
     assert "viewer.html" in url
 
@@ -68,14 +69,13 @@ def test_open_browser_skipped_when_tab_reconnects_during_grace():
     client = ViewerClient(port=_unique_port(4), open_browser=True)
 
     def simulate_reconnect():
-        """Simulate a browser tab connecting after a short delay."""
-        time.sleep(0.5)
+        time.sleep(0.3)
         client._connected_event.set()
 
     t = threading.Thread(target=simulate_reconnect, daemon=True)
     t.start()
 
-    with patch("threejs_viewer.client.webbrowser.open", return_value=True) as mock_open:
+    with patch.object(client, "_open_viewer_in_browser") as mock_open:
         client.connect(timeout=5.0)
     mock_open.assert_not_called()
     client.disconnect()
@@ -85,7 +85,7 @@ def test_open_browser_skipped_when_tab_reconnects_during_grace():
 def test_timeout_zero_does_not_open_browser():
     """timeout=0 should not attempt to open browser (no time to connect)."""
     client = ViewerClient(port=_unique_port(5), open_browser=True)
-    with patch("threejs_viewer.client.webbrowser.open") as mock_open:
+    with patch.object(client, "_open_viewer_in_browser") as mock_open:
         err = _connect_and_catch(client, timeout=0)
     mock_open.assert_not_called()
     assert isinstance(err, TimeoutError)
@@ -104,9 +104,9 @@ def test_timeout_respects_deadline():
     """Total wait should not significantly exceed the requested timeout."""
     client = ViewerClient(port=_unique_port(7), open_browser=False)
     start = time.monotonic()
-    _connect_and_catch(client, timeout=0.5)
+    _connect_and_catch(client, timeout=0.3)
     elapsed = time.monotonic() - start
-    assert elapsed < 1.5  # generous margin, but should be ~0.5s
+    assert elapsed < 1.0
 
 
 def test_constructor_open_browser_default():

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- `ViewerClient(open_browser=True)` automatically opens the viewer in the default browser if no existing tab reconnects within 2.5 seconds
- New `open_browser` parameter on constructor (default `True`) — also available via `viewer()` convenience function
- Set `open_browser=False` for headless/CI/remote environments
- New `viewer_url` property returns the full `file://` URL with `?ws_port=` for manual opening
- Gracefully handles `webbrowser.open()` failures (falls back to printing the full URL)
- Proper deadline-based timeout tracking so total wait never exceeds the `timeout` parameter
- Servers are cleaned up on timeout so the port is released

### Fixes applied after review

- **Cross-platform URL**: Use `Path.as_uri()` instead of f-string for correct `file://` URLs on Windows and paths with spaces
- **ws_port query param**: Always pass `?ws_port=` so non-default ports work correctly — in the opened URL, all printed messages, and the TimeoutError
- **API design**: Moved `open_browser` from `connect()` to constructor, threaded through `viewer()` convenience function and context manager
- **Grace period**: Increased from 1s to 2.5s to reliably cover the browser's reconnect cycle (500ms onclose + up to 1000ms probe retry)
- **Fallback handling**: Check `webbrowser.open()` return value; narrow `except` to `(OSError, webbrowser.Error)`; print full URL in all fallback messages
- **UX**: Print full `viewer_url` (with `ws_port`) when `open_browser=False` and in TimeoutError, so manual opening works on non-default ports
- **Server cleanup**: `disconnect()` on timeout so HTTP/WS servers release the port
- **Edge case**: Skip browser auto-open when `timeout=0`; reject negative timeout with `ValueError`
- **Test fixture**: Set `open_browser=False` in `viewer_client` fixture to prevent accidental browser opens
- **Tests**: 9 new unit tests covering all connect() code paths
- **Docs**: Updated README, CLAUDE.md, DESIGN.md, CHANGELOG; fixed pre-existing DESIGN.md typo (`set_transforms` → `set_matrix`)

## Test plan

- [x] Run `uv run python examples/01_primitives.py` with no browser tab open — viewer should auto-open
- [x] Run the same example with a browser tab already open — should reconnect within 2.5s without opening a new tab
- [x] Run with `ViewerClient(open_browser=False).connect()` — should not open browser, should print full viewer URL
- [x] Run with `ViewerClient(port=5700).connect()` — opened URL should include `?ws_port=5700`
- [x] All 114 tests pass (`uv run pytest -v`)