### PR TITLE
Add resize(), frameAll(), and dynamic near/far planes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.0.16
+
+Public viewer API and dynamic camera improvements.
+
+### New features
+
+- **`resize(width, height)`** — public method to force viewer resize (e.g. after container show/hide)
+- **`frameAll()`** — resets orbit controls and positions camera to frame all scene objects
+- **Dynamic near/far planes** — perspective camera near/far recomputed from scene bounding sphere, preventing geometry clipping on zoom-in
+
+### Bug fixes
+
+- Fixed `__version__` out of sync with package version (was stuck at 0.0.13)
+
 ## 0.0.15
 
 Embeddable viewer: extract monolithic viewer.html into modular ES module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Changelog
 
-## 0.0.16
-
-Public viewer API and dynamic camera improvements.
+## Unreleased
 
 ### New features
 
 - **`resize(width, height)`** — public method to force viewer resize (e.g. after container show/hide)
 - **`frameAll()`** — resets orbit controls and positions camera to frame all scene objects
 - **Dynamic near/far planes** — perspective camera near/far recomputed from scene bounding sphere, preventing geometry clipping on zoom-in
+- **Version placeholder** — source uses `0.0.0-dev`, CI substitutes real version at build time
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.16
 
 ### New features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ uv run python examples/04_flying_teapots.py
 Source files use `0.0.0-dev` as a placeholder version. CI replaces it before build/publish:
 ```bash
 sed -i "s/0\.0\.0-dev/$VERSION/g" pyproject.toml src/threejs_viewer/__init__.py src/threejs_viewer/viewer/viewer.js
+uv run python src/threejs_viewer/viewer/build.py  # regenerate viewer.html with substituted version
 ```
-The placeholder appears in three files: `pyproject.toml`, `src/threejs_viewer/__init__.py`, `src/threejs_viewer/viewer/viewer.js`. Never commit a real version number — always keep `0.0.0-dev`.
+The placeholder appears in three files: `pyproject.toml`, `src/threejs_viewer/__init__.py`, `src/threejs_viewer/viewer/viewer.js`. The build step propagates the version into `viewer.html`. Never commit a real version number — always keep `0.0.0-dev`.
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ uv run python examples/01_primitives.py
 uv run python examples/04_flying_teapots.py
 ```
 
+## Versioning
+
+Source files use `0.0.0-dev` as a placeholder version. CI replaces it before build/publish:
+```bash
+sed -i "s/0\.0\.0-dev/$VERSION/g" pyproject.toml src/threejs_viewer/__init__.py src/threejs_viewer/viewer/viewer.js
+```
+The placeholder appears in three files: `pyproject.toml`, `src/threejs_viewer/__init__.py`, `src/threejs_viewer/viewer/viewer.js`. Never commit a real version number — always keep `0.0.0-dev`.
+
 ## Project Overview
 
 A lightweight Three.js viewer designed to be controlled from Python/Jupyter notebooks. Primary use case: visualizing 3D data and animations at 60fps. The browser viewer persists across Python script restarts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.16"
+version = "0.0.0-dev"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.15"
+version = "0.0.16"
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -29,4 +29,4 @@ __all__ = [
     "Toolpath",
 ]
 
-__version__ = "0.0.16"
+__version__ = "0.0.0-dev"

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -29,4 +29,4 @@ __all__ = [
     "Toolpath",
 ]
 
-__version__ = "0.0.13"
+__version__ = "0.0.16"

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2463,7 +2463,7 @@ class ThreeJSViewer {
 
 // Standalone instantiation
 const container = document.getElementById('viewer-container');
-new ThreeJSViewer(container, {
+window['threejs-viewer'] = new ThreeJSViewer(container, {
     htmlTemplate: HTML_TEMPLATE,
     cubemapData: CUBEMAP_DATA
 });

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2291,7 +2291,7 @@ class ThreeJSViewer {
     _updateSceneBounds() {
         const box = new THREE.Box3();
         for (const obj of this._objects.values()) {
-            obj.updateWorldMatrix(true, false);
+            obj.updateWorldMatrix(true, true);
             box.expandByObject(obj);
         }
         if (box.isEmpty()) {
@@ -2313,8 +2313,14 @@ class ThreeJSViewer {
         const radius = this._sceneSphere.radius;
         if (radius === 0) return;
         const dist = this._perspCamera.position.distanceTo(this._sceneSphere.center);
-        this._perspCamera.near = Math.max(0.001, (dist - radius * 1.5) * 0.5);
-        this._perspCamera.far = Math.max(dist + radius * 1.5, 100);
+        const nextNear = Math.max(0.001, (dist - radius * 1.5) * 0.5);
+        const nextFar = Math.max(dist + radius * 1.5, 100);
+        if (
+            Math.abs(this._perspCamera.near - nextNear) < 1e-6 &&
+            Math.abs(this._perspCamera.far - nextFar) < 1e-6
+        ) return;
+        this._perspCamera.near = nextNear;
+        this._perspCamera.far = nextFar;
         this._perspCamera.updateProjectionMatrix();
     }
 
@@ -2401,17 +2407,20 @@ class ThreeJSViewer {
         if (this._isOrtho) {
             const w = this.container.clientWidth;
             const h = this.container.clientHeight;
+            if (w === 0 || h === 0) return;
             const aspect = w / h;
             const halfHeight = Math.max(size.z, size.y) / 2 * 1.2;
             const halfWidth = Math.max(size.x, size.y) / 2 * 1.2;
-            const fitHalf = Math.max(halfHeight, halfWidth / aspect);
+            const fitHalf = Math.max(halfHeight, halfWidth / aspect, 1e-6);
             this._orthoCamera.zoom = ORTHO_FRUSTUM / fitHalf;
             this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
             this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
             this._orthoCamera.top = ORTHO_FRUSTUM;
             this._orthoCamera.bottom = -ORTHO_FRUSTUM;
             this._orthoCamera.updateProjectionMatrix();
-            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            const dir = this._camera.position.clone().sub(this._controls.target);
+            if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
+            else dir.normalize();
             this._camera.position.copy(center).addScaledVector(dir, maxDim * 2);
         } else {
             const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2425,8 +2425,9 @@ class ThreeJSViewer {
         } else {
             const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
             const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
-            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            const dir = this._camera.position.clone().sub(this._controls.target);
             if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
+            else dir.normalize();
             this._camera.position.copy(center).addScaledVector(dir, dist);
         }
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2463,7 +2463,7 @@ class ThreeJSViewer {
 
 // Standalone instantiation
 const container = document.getElementById('viewer-container');
-window['threejs-viewer'] = new ThreeJSViewer(container, {
+window.threejsViewer = new ThreeJSViewer(container, {
     htmlTemplate: HTML_TEMPLATE,
     cubemapData: CUBEMAP_DATA
 });

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -817,6 +817,7 @@ class ThreeJSViewer {
         // Scene bounds caching for dynamic near/far
         this._sceneSphere = new THREE.Sphere();
         this._sceneBoundsDirty = true;
+        this._boundsFrameCounter = 0;
 
         // ResizeObserver
         this._resizeObserver = new ResizeObserver(entries => {
@@ -2289,12 +2290,10 @@ class ThreeJSViewer {
 
     _updateSceneBounds() {
         const box = new THREE.Box3();
-        this._scene.traverse(child => {
-            if (!child.geometry) return;
-            if (child === this._gridHelper) return;
-            if (this._isClipHelper(child)) return;
-            box.expandByObject(child);
-        });
+        for (const obj of this._objects.values()) {
+            obj.updateWorldMatrix(true, false);
+            box.expandByObject(obj);
+        }
         if (box.isEmpty()) {
             this._sceneSphere.set(new THREE.Vector3(), 0);
         } else {
@@ -2305,7 +2304,12 @@ class ThreeJSViewer {
 
     _updateNearFar() {
         if (this._isOrtho) return;
-        if (this._sceneBoundsDirty) this._updateSceneBounds();
+        // Recompute bounds on dirty flag or every 30 frames (~0.5s) to catch transform changes
+        this._boundsFrameCounter++;
+        if (this._sceneBoundsDirty || this._boundsFrameCounter >= 30) {
+            this._updateSceneBounds();
+            this._boundsFrameCounter = 0;
+        }
         const radius = this._sceneSphere.radius;
         if (radius === 0) return;
         const dist = this._perspCamera.position.distanceTo(this._sceneSphere.center);
@@ -2413,7 +2417,7 @@ class ThreeJSViewer {
             const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
             const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
             const dir = this._camera.position.clone().sub(this._controls.target).normalize();
-            if (dir.lengthSq() === 0) dir.set(1, -1, 1).normalize();
+            if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
             this._camera.position.copy(center).addScaledVector(dir, dist);
         }
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -814,22 +814,14 @@ class ThreeJSViewer {
             '3ds': new TDSLoader()
         };
 
+        // Scene bounds caching for dynamic near/far
+        this._sceneSphere = new THREE.Sphere();
+        this._sceneBoundsDirty = true;
+
         // ResizeObserver
         this._resizeObserver = new ResizeObserver(entries => {
             const { width, height } = entries[0].contentRect;
-            if (width === 0 || height === 0) return;
-            const aspect = width / height;
-            this._perspCamera.aspect = aspect;
-            this._perspCamera.updateProjectionMatrix();
-            this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
-            this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
-            this._orthoCamera.updateProjectionMatrix();
-            this._renderer.setSize(width, height);
-            this._objects.forEach((obj) => {
-                if (obj.material && obj.material.resolution) {
-                    obj.material.resolution.set(width, height);
-                }
-            });
+            this.resize(width, height);
         });
         this._resizeObserver.observe(this.container);
     }
@@ -1237,6 +1229,7 @@ class ThreeJSViewer {
         } else {
             this._scene.add(obj);
         }
+        this._sceneBoundsDirty = true;
     }
 
     _applyTransform(obj, transform) {
@@ -1374,6 +1367,7 @@ class ThreeJSViewer {
             }
             if (obj.parent) obj.parent.remove(obj);
             this._objects.delete(id);
+            this._sceneBoundsDirty = true;
             const mixer = this._mixers.get(id);
             if (mixer) { mixer.stopAllAction(); this._mixers.delete(id); }
             obj.traverse((child) => {
@@ -2291,6 +2285,35 @@ class ThreeJSViewer {
         doConnect();
     }
 
+    // ========== Dynamic Near/Far ==========
+
+    _updateSceneBounds() {
+        const box = new THREE.Box3();
+        this._scene.traverse(child => {
+            if (!child.geometry) return;
+            if (child === this._gridHelper) return;
+            if (this._isClipHelper(child)) return;
+            box.expandByObject(child);
+        });
+        if (box.isEmpty()) {
+            this._sceneSphere.set(new THREE.Vector3(), 0);
+        } else {
+            box.getBoundingSphere(this._sceneSphere);
+        }
+        this._sceneBoundsDirty = false;
+    }
+
+    _updateNearFar() {
+        if (this._isOrtho) return;
+        if (this._sceneBoundsDirty) this._updateSceneBounds();
+        const radius = this._sceneSphere.radius;
+        if (radius === 0) return;
+        const dist = this._perspCamera.position.distanceTo(this._sceneSphere.center);
+        this._perspCamera.near = Math.max(0.001, (dist - radius * 1.5) * 0.5);
+        this._perspCamera.far = Math.max(dist + radius * 1.5, 100);
+        this._perspCamera.updateProjectionMatrix();
+    }
+
     // ========== Render Loop ==========
 
     _animate() {
@@ -2325,12 +2348,76 @@ class ThreeJSViewer {
         }
 
         this._controls.update();
+        this._updateNearFar();
 
         if (this._viewHelper.animating) this._viewHelper.update(frameDelta);
         this._renderer.autoClear = true;
         this._renderer.render(this._scene, this._camera);
         this._renderer.autoClear = false;
         this._viewHelper.render(this._renderer);
+    }
+
+    // ========== Public API ==========
+
+    resize(width, height) {
+        width = width ?? this.container.clientWidth;
+        height = height ?? this.container.clientHeight;
+        if (width === 0 || height === 0) return;
+        const aspect = width / height;
+        this._perspCamera.aspect = aspect;
+        this._perspCamera.updateProjectionMatrix();
+        this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
+        this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
+        this._orthoCamera.updateProjectionMatrix();
+        this._renderer.setSize(width, height);
+        this._objects.forEach((obj) => {
+            if (obj.material && obj.material.resolution) {
+                obj.material.resolution.set(width, height);
+            }
+        });
+    }
+
+    frameAll() {
+        const bbox = new THREE.Box3();
+        this._scene.traverse(child => {
+            if (!child.geometry) return;
+            if (child === this._gridHelper) return;
+            if (this._isClipHelper(child)) return;
+            child.updateWorldMatrix(true, false);
+            bbox.expandByObject(child);
+        });
+        if (bbox.isEmpty()) return;
+
+        const center = bbox.getCenter(new THREE.Vector3());
+        const size = bbox.getSize(new THREE.Vector3());
+        const maxDim = Math.max(size.x, size.y, size.z);
+
+        this._controls.target.copy(center);
+
+        if (this._isOrtho) {
+            const w = this.container.clientWidth;
+            const h = this.container.clientHeight;
+            const aspect = w / h;
+            const halfHeight = Math.max(size.z, size.y) / 2 * 1.2;
+            const halfWidth = Math.max(size.x, size.y) / 2 * 1.2;
+            const fitHalf = Math.max(halfHeight, halfWidth / aspect);
+            this._orthoCamera.zoom = ORTHO_FRUSTUM / fitHalf;
+            this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
+            this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
+            this._orthoCamera.top = ORTHO_FRUSTUM;
+            this._orthoCamera.bottom = -ORTHO_FRUSTUM;
+            this._orthoCamera.updateProjectionMatrix();
+            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            this._camera.position.copy(center).addScaledVector(dir, maxDim * 2);
+        } else {
+            const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
+            const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
+            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            if (dir.lengthSq() === 0) dir.set(1, -1, 1).normalize();
+            this._camera.position.copy(center).addScaledVector(dir, dist);
+        }
+
+        this._controls.update();
     }
 
     // ========== Destroy ==========

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -473,7 +473,7 @@ import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
-const VIEWER_VERSION = '0.0.16';
+const VIEWER_VERSION = '0.0.0-dev';
 
 const ORTHO_FRUSTUM = 10;
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2423,8 +2423,12 @@ class ThreeJSViewer {
             else dir.normalize();
             this._camera.position.copy(center).addScaledVector(dir, maxDim * 2);
         } else {
-            const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
-            const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
+            const vFov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
+            const aspect = this._perspCamera.aspect || 1;
+            const hFov = Math.atan(Math.tan(vFov) * aspect);
+            const distV = Math.max(size.y, size.z) / 2 / Math.tan(vFov);
+            const distH = Math.max(size.x, size.y) / 2 / Math.tan(hFov);
+            const dist = Math.max(distV, distH) * 1.2;
             const dir = this._camera.position.clone().sub(this._controls.target);
             if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
             else dir.normalize();

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -473,7 +473,7 @@ import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
-const VIEWER_VERSION = '0.0.15';
+const VIEWER_VERSION = '0.0.16';
 
 const ORTHO_FRUSTUM = 10;
 

--- a/src/threejs_viewer/viewer/build.py
+++ b/src/threejs_viewer/viewer/build.py
@@ -97,7 +97,7 @@ def build():
 
 // Standalone instantiation
 const container = document.getElementById('viewer-container');
-window['threejs-viewer'] = new ThreeJSViewer(container, {{
+window.threejsViewer = new ThreeJSViewer(container, {{
     htmlTemplate: HTML_TEMPLATE,
     cubemapData: CUBEMAP_DATA
 }});

--- a/src/threejs_viewer/viewer/build.py
+++ b/src/threejs_viewer/viewer/build.py
@@ -97,7 +97,7 @@ def build():
 
 // Standalone instantiation
 const container = document.getElementById('viewer-container');
-new ThreeJSViewer(container, {{
+window['threejs-viewer'] = new ThreeJSViewer(container, {{
     htmlTemplate: HTML_TEMPLATE,
     cubemapData: CUBEMAP_DATA
 }});

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -1965,8 +1965,9 @@ export class ThreeJSViewer {
         } else {
             const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
             const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
-            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            const dir = this._camera.position.clone().sub(this._controls.target);
             if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
+            else dir.normalize();
             this._camera.position.copy(center).addScaledVector(dir, dist);
         }
 

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -13,7 +13,7 @@ import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
-const VIEWER_VERSION = '0.0.15';
+const VIEWER_VERSION = '0.0.16';
 
 const ORTHO_FRUSTUM = 10;
 

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -1963,8 +1963,12 @@ export class ThreeJSViewer {
             else dir.normalize();
             this._camera.position.copy(center).addScaledVector(dir, maxDim * 2);
         } else {
-            const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
-            const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
+            const vFov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
+            const aspect = this._perspCamera.aspect || 1;
+            const hFov = Math.atan(Math.tan(vFov) * aspect);
+            const distV = Math.max(size.y, size.z) / 2 / Math.tan(vFov);
+            const distH = Math.max(size.x, size.y) / 2 / Math.tan(hFov);
+            const dist = Math.max(distV, distH) * 1.2;
             const dir = this._camera.position.clone().sub(this._controls.target);
             if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
             else dir.normalize();

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -357,6 +357,7 @@ export class ThreeJSViewer {
         // Scene bounds caching for dynamic near/far
         this._sceneSphere = new THREE.Sphere();
         this._sceneBoundsDirty = true;
+        this._boundsFrameCounter = 0;
 
         // ResizeObserver
         this._resizeObserver = new ResizeObserver(entries => {
@@ -1829,12 +1830,10 @@ export class ThreeJSViewer {
 
     _updateSceneBounds() {
         const box = new THREE.Box3();
-        this._scene.traverse(child => {
-            if (!child.geometry) return;
-            if (child === this._gridHelper) return;
-            if (this._isClipHelper(child)) return;
-            box.expandByObject(child);
-        });
+        for (const obj of this._objects.values()) {
+            obj.updateWorldMatrix(true, false);
+            box.expandByObject(obj);
+        }
         if (box.isEmpty()) {
             this._sceneSphere.set(new THREE.Vector3(), 0);
         } else {
@@ -1845,7 +1844,12 @@ export class ThreeJSViewer {
 
     _updateNearFar() {
         if (this._isOrtho) return;
-        if (this._sceneBoundsDirty) this._updateSceneBounds();
+        // Recompute bounds on dirty flag or every 30 frames (~0.5s) to catch transform changes
+        this._boundsFrameCounter++;
+        if (this._sceneBoundsDirty || this._boundsFrameCounter >= 30) {
+            this._updateSceneBounds();
+            this._boundsFrameCounter = 0;
+        }
         const radius = this._sceneSphere.radius;
         if (radius === 0) return;
         const dist = this._perspCamera.position.distanceTo(this._sceneSphere.center);
@@ -1953,7 +1957,7 @@ export class ThreeJSViewer {
             const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
             const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
             const dir = this._camera.position.clone().sub(this._controls.target).normalize();
-            if (dir.lengthSq() === 0) dir.set(1, -1, 1).normalize();
+            if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
             this._camera.position.copy(center).addScaledVector(dir, dist);
         }
 

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -1831,7 +1831,7 @@ export class ThreeJSViewer {
     _updateSceneBounds() {
         const box = new THREE.Box3();
         for (const obj of this._objects.values()) {
-            obj.updateWorldMatrix(true, false);
+            obj.updateWorldMatrix(true, true);
             box.expandByObject(obj);
         }
         if (box.isEmpty()) {
@@ -1853,8 +1853,14 @@ export class ThreeJSViewer {
         const radius = this._sceneSphere.radius;
         if (radius === 0) return;
         const dist = this._perspCamera.position.distanceTo(this._sceneSphere.center);
-        this._perspCamera.near = Math.max(0.001, (dist - radius * 1.5) * 0.5);
-        this._perspCamera.far = Math.max(dist + radius * 1.5, 100);
+        const nextNear = Math.max(0.001, (dist - radius * 1.5) * 0.5);
+        const nextFar = Math.max(dist + radius * 1.5, 100);
+        if (
+            Math.abs(this._perspCamera.near - nextNear) < 1e-6 &&
+            Math.abs(this._perspCamera.far - nextFar) < 1e-6
+        ) return;
+        this._perspCamera.near = nextNear;
+        this._perspCamera.far = nextFar;
         this._perspCamera.updateProjectionMatrix();
     }
 
@@ -1941,17 +1947,20 @@ export class ThreeJSViewer {
         if (this._isOrtho) {
             const w = this.container.clientWidth;
             const h = this.container.clientHeight;
+            if (w === 0 || h === 0) return;
             const aspect = w / h;
             const halfHeight = Math.max(size.z, size.y) / 2 * 1.2;
             const halfWidth = Math.max(size.x, size.y) / 2 * 1.2;
-            const fitHalf = Math.max(halfHeight, halfWidth / aspect);
+            const fitHalf = Math.max(halfHeight, halfWidth / aspect, 1e-6);
             this._orthoCamera.zoom = ORTHO_FRUSTUM / fitHalf;
             this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
             this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
             this._orthoCamera.top = ORTHO_FRUSTUM;
             this._orthoCamera.bottom = -ORTHO_FRUSTUM;
             this._orthoCamera.updateProjectionMatrix();
-            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            const dir = this._camera.position.clone().sub(this._controls.target);
+            if (dir.lengthSq() < 1e-10) dir.set(1, -1, 1).normalize();
+            else dir.normalize();
             this._camera.position.copy(center).addScaledVector(dir, maxDim * 2);
         } else {
             const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -13,7 +13,7 @@ import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
-const VIEWER_VERSION = '0.0.16';
+const VIEWER_VERSION = '0.0.0-dev';
 
 const ORTHO_FRUSTUM = 10;
 

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -354,22 +354,14 @@ export class ThreeJSViewer {
             '3ds': new TDSLoader()
         };
 
+        // Scene bounds caching for dynamic near/far
+        this._sceneSphere = new THREE.Sphere();
+        this._sceneBoundsDirty = true;
+
         // ResizeObserver
         this._resizeObserver = new ResizeObserver(entries => {
             const { width, height } = entries[0].contentRect;
-            if (width === 0 || height === 0) return;
-            const aspect = width / height;
-            this._perspCamera.aspect = aspect;
-            this._perspCamera.updateProjectionMatrix();
-            this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
-            this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
-            this._orthoCamera.updateProjectionMatrix();
-            this._renderer.setSize(width, height);
-            this._objects.forEach((obj) => {
-                if (obj.material && obj.material.resolution) {
-                    obj.material.resolution.set(width, height);
-                }
-            });
+            this.resize(width, height);
         });
         this._resizeObserver.observe(this.container);
     }
@@ -777,6 +769,7 @@ export class ThreeJSViewer {
         } else {
             this._scene.add(obj);
         }
+        this._sceneBoundsDirty = true;
     }
 
     _applyTransform(obj, transform) {
@@ -914,6 +907,7 @@ export class ThreeJSViewer {
             }
             if (obj.parent) obj.parent.remove(obj);
             this._objects.delete(id);
+            this._sceneBoundsDirty = true;
             const mixer = this._mixers.get(id);
             if (mixer) { mixer.stopAllAction(); this._mixers.delete(id); }
             obj.traverse((child) => {
@@ -1831,6 +1825,35 @@ export class ThreeJSViewer {
         doConnect();
     }
 
+    // ========== Dynamic Near/Far ==========
+
+    _updateSceneBounds() {
+        const box = new THREE.Box3();
+        this._scene.traverse(child => {
+            if (!child.geometry) return;
+            if (child === this._gridHelper) return;
+            if (this._isClipHelper(child)) return;
+            box.expandByObject(child);
+        });
+        if (box.isEmpty()) {
+            this._sceneSphere.set(new THREE.Vector3(), 0);
+        } else {
+            box.getBoundingSphere(this._sceneSphere);
+        }
+        this._sceneBoundsDirty = false;
+    }
+
+    _updateNearFar() {
+        if (this._isOrtho) return;
+        if (this._sceneBoundsDirty) this._updateSceneBounds();
+        const radius = this._sceneSphere.radius;
+        if (radius === 0) return;
+        const dist = this._perspCamera.position.distanceTo(this._sceneSphere.center);
+        this._perspCamera.near = Math.max(0.001, (dist - radius * 1.5) * 0.5);
+        this._perspCamera.far = Math.max(dist + radius * 1.5, 100);
+        this._perspCamera.updateProjectionMatrix();
+    }
+
     // ========== Render Loop ==========
 
     _animate() {
@@ -1865,12 +1888,76 @@ export class ThreeJSViewer {
         }
 
         this._controls.update();
+        this._updateNearFar();
 
         if (this._viewHelper.animating) this._viewHelper.update(frameDelta);
         this._renderer.autoClear = true;
         this._renderer.render(this._scene, this._camera);
         this._renderer.autoClear = false;
         this._viewHelper.render(this._renderer);
+    }
+
+    // ========== Public API ==========
+
+    resize(width, height) {
+        width = width ?? this.container.clientWidth;
+        height = height ?? this.container.clientHeight;
+        if (width === 0 || height === 0) return;
+        const aspect = width / height;
+        this._perspCamera.aspect = aspect;
+        this._perspCamera.updateProjectionMatrix();
+        this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
+        this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
+        this._orthoCamera.updateProjectionMatrix();
+        this._renderer.setSize(width, height);
+        this._objects.forEach((obj) => {
+            if (obj.material && obj.material.resolution) {
+                obj.material.resolution.set(width, height);
+            }
+        });
+    }
+
+    frameAll() {
+        const bbox = new THREE.Box3();
+        this._scene.traverse(child => {
+            if (!child.geometry) return;
+            if (child === this._gridHelper) return;
+            if (this._isClipHelper(child)) return;
+            child.updateWorldMatrix(true, false);
+            bbox.expandByObject(child);
+        });
+        if (bbox.isEmpty()) return;
+
+        const center = bbox.getCenter(new THREE.Vector3());
+        const size = bbox.getSize(new THREE.Vector3());
+        const maxDim = Math.max(size.x, size.y, size.z);
+
+        this._controls.target.copy(center);
+
+        if (this._isOrtho) {
+            const w = this.container.clientWidth;
+            const h = this.container.clientHeight;
+            const aspect = w / h;
+            const halfHeight = Math.max(size.z, size.y) / 2 * 1.2;
+            const halfWidth = Math.max(size.x, size.y) / 2 * 1.2;
+            const fitHalf = Math.max(halfHeight, halfWidth / aspect);
+            this._orthoCamera.zoom = ORTHO_FRUSTUM / fitHalf;
+            this._orthoCamera.left = -ORTHO_FRUSTUM * aspect;
+            this._orthoCamera.right = ORTHO_FRUSTUM * aspect;
+            this._orthoCamera.top = ORTHO_FRUSTUM;
+            this._orthoCamera.bottom = -ORTHO_FRUSTUM;
+            this._orthoCamera.updateProjectionMatrix();
+            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            this._camera.position.copy(center).addScaledVector(dir, maxDim * 2);
+        } else {
+            const fov = THREE.MathUtils.degToRad(this._perspCamera.fov / 2);
+            const dist = (maxDim / 2) / Math.tan(fov) * 1.2;
+            const dir = this._camera.position.clone().sub(this._controls.target).normalize();
+            if (dir.lengthSq() === 0) dir.set(1, -1, 1).normalize();
+            this._camera.position.copy(center).addScaledVector(dir, dist);
+        }
+
+        this._controls.update();
     }
 
     // ========== Destroy ==========

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.15"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.16"
+version = "0.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- **`resize(width, height)`**: Public method extracted from the internal ResizeObserver callback. Lets host apps force a resize when the container transitions from `display:none`.
- **`frameAll()`**: Resets orbit controls target to scene bounding-box center and positions the camera to frame all objects. Works in both perspective and orthographic modes, handles portrait aspect ratios.
- **Dynamic near/far planes**: Caches the scene bounding sphere (dirty flag on object add/remove, periodic recompute every 30 frames) and recomputes perspective camera near/far each frame based on camera distance. Keeps near as far forward as possible for depth precision while preventing geometry clipping.
- **`window.threejsViewer`**: Standalone viewer.html now exposes the viewer instance on `window` for console access.
- **Version placeholder**: Source files use `0.0.0-dev`, CI substitutes real version via sed before build/publish.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] `uv run pytest` — 114 tests pass
- [x] Manual: run `examples/01_primitives.py`, zoom in close, verify no near-plane clipping
- [x] Manual: run `threejsViewer.frameAll()` in browser console, verify camera frames all objects
- [x] Manual: run `threejsViewer.resize()` in browser console after hiding/showing container

🤖 Generated with [Claude Code](https://claude.com/claude-code)