### PR TITLE
Add camera tracking for animation playback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,12 @@
       "WebSearch",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(git checkout:*)",
+      "Bash(git rm:*)",
+      "Bash(gh pr:*)",
+      "Bash(git stash:*)",
+      "Bash(git diff:*)"
     ],
     "deny": [],
     "ask": []

--- a/examples/11_toolpath.py
+++ b/examples/11_toolpath.py
@@ -113,7 +113,7 @@ transforms[:, 1, 13] = tips[:, 1]
 transforms[:, 1, 14] = nz_z
 
 # Build animation — fully binary, no Python loop
-animation = Animation(loop=True)
+animation = Animation(loop=True, camera_follow="nozzle")
 animation.set_frame_times(frame_times)
 animation.set_transform_data(["path_tube", "nozzle"], transforms)
 animation.set_draw_range_data(["path_tube"], draw_fracs[:, None])

--- a/src/threejs_viewer/animation.py
+++ b/src/threejs_viewer/animation.py
@@ -77,6 +77,12 @@ class Animation:
     frames: list[Frame] = field(default_factory=list)
     loop: bool = True
     markers: list[Marker] = field(default_factory=list)
+    camera_follow: str | None = None
+    camera_lookat: str | None = None
+
+    def __post_init__(self):
+        if self.camera_follow and self.camera_lookat:
+            raise ValueError("camera_follow and camera_lookat are mutually exclusive")
 
     # Generic binary channels for fast transfer.
     _channels: list[AnimationChannel] = field(default_factory=list, repr=False)
@@ -186,13 +192,25 @@ class Animation:
         """Convenience: add a 'clip_times' channel."""
         self.add_channel("clip_times", object_ids, data, dtype="float32", stride=1)
 
+    def set_camera_target(self, data: np.ndarray) -> None:
+        """Convenience: add a 'camera_target' channel with stride=3."""
+        self.add_channel(
+            "camera_target", ["__camera__"], data, dtype="float32", stride=3
+        )
+
+    def set_camera_position(self, data: np.ndarray) -> None:
+        """Convenience: add a 'camera_position' channel with stride=3."""
+        self.add_channel(
+            "camera_position", ["__camera__"], data, dtype="float32", stride=3
+        )
+
     def add_marker(self, time: float, label: str, color: int = 0xFF0000) -> None:
         """Add a labeled marker on the timeline."""
         self.markers.append(Marker(time=time, label=label, color=color))
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        return {
+        result = {
             "duration": self.duration,
             "fps": self.fps,
             "loop": self.loop,
@@ -213,6 +231,11 @@ class Animation:
                 for m in self.markers
             ],
         }
+        if self.camera_follow:
+            result["camera_follow"] = self.camera_follow
+        if self.camera_lookat:
+            result["camera_lookat"] = self.camera_lookat
+        return result
 
 
 def merge_animation_points(

--- a/src/threejs_viewer/animation.py
+++ b/src/threejs_viewer/animation.py
@@ -81,7 +81,7 @@ class Animation:
     camera_lookat: str | None = None
 
     def __post_init__(self):
-        if self.camera_follow and self.camera_lookat:
+        if self.camera_follow is not None and self.camera_lookat is not None:
             raise ValueError("camera_follow and camera_lookat are mutually exclusive")
 
     # Generic binary channels for fast transfer.
@@ -231,9 +231,9 @@ class Animation:
                 for m in self.markers
             ],
         }
-        if self.camera_follow:
+        if self.camera_follow is not None:
             result["camera_follow"] = self.camera_follow
-        if self.camera_lookat:
+        if self.camera_lookat is not None:
             result["camera_lookat"] = self.camera_lookat
         return result
 

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -1042,6 +1042,10 @@ class ViewerClient:
             "channels": channel_manifest,
             "frames_meta": frames_meta,
         }
+        if animation.camera_follow is not None:
+            header["camera_follow"] = animation.camera_follow
+        if animation.camera_lookat is not None:
+            header["camera_lookat"] = animation.camera_lookat
         self._send(header)
 
     def stop_animation(self) -> None:

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -58,14 +58,16 @@
             background: none;
             border: none;
             color: #aaa;
-            width: 28px;
+            min-width: 28px;
             height: 28px;
+            padding: 0 6px;
             border-radius: 4px;
             cursor: pointer;
-            font-size: 15px;
+            font-size: 13px;
             display: flex;
             align-items: center;
             justify-content: center;
+            gap: 3px;
             transition: background 0.15s, color 0.15s;
         }
         .threejs-viewer .toolbar-btn:hover { background: rgba(255,255,255,0.1); color: white; }
@@ -381,9 +383,9 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
     <div class="tjsv-status-dot disconnected" title="Disconnected"></div>
     <span class="tjsv-status-text">Disconnected</span>
     <div class="toolbar-sep"></div>
-    <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane (C)">&#x2702;</button>
+    <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane">&#x2702; C</button>
     <button class="toolbar-btn tjsv-btn-ortho" title="Orthographic / Perspective (O)">P</button>
-    <button class="toolbar-btn tjsv-btn-track" title="Camera tracking (T)" style="display:none">&#x229A;</button>
+    <button class="toolbar-btn tjsv-btn-track" title="Camera tracking" style="display:none">&#x229A; T</button>
 </div>
 
 <div class="tjsv-clipping-panel">
@@ -455,7 +457,7 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
         <button class="loop-toggle active tjsv-btn-loop" title="Toggle loop (L)">&#x27F3; Loop</button>
         <div class="frame-display">Frame <span class="tjsv-current-frame">0</span>/<span class="tjsv-total-frames">0</span></div>
     </div>
-    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | T: Track | &uarr;&darr;: Speed</div>
+    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
 </div>
 `;
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -200,8 +200,7 @@
             min-width: 50px;
             text-align: center;
         }
-        .threejs-viewer .loop-toggle,
-        .threejs-viewer .track-toggle {
+        .threejs-viewer .loop-toggle {
             background: #444;
             border: none;
             color: white;
@@ -210,10 +209,8 @@
             cursor: pointer;
             font-size: 12px;
         }
-        .threejs-viewer .loop-toggle:hover,
-        .threejs-viewer .track-toggle:hover { background: #555; }
-        .threejs-viewer .loop-toggle.active,
-        .threejs-viewer .track-toggle.active { background: #0066cc; }
+        .threejs-viewer .loop-toggle:hover { background: #555; }
+        .threejs-viewer .loop-toggle.active { background: #0066cc; }
         .threejs-viewer .frame-display {
             font-family: monospace;
             font-size: 11px;
@@ -386,6 +383,7 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
     <div class="toolbar-sep"></div>
     <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane (C)">&#x2702;</button>
     <button class="toolbar-btn tjsv-btn-ortho" title="Orthographic / Perspective (O)">P</button>
+    <button class="toolbar-btn tjsv-btn-track" title="Camera tracking (T)" style="display:none">&#x229A;</button>
 </div>
 
 <div class="tjsv-clipping-panel">
@@ -455,7 +453,6 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
             <button class="tjsv-btn-faster" title="Faster (&uarr)">+</button>
         </div>
         <button class="loop-toggle active tjsv-btn-loop" title="Toggle loop (L)">&#x27F3; Loop</button>
-        <button class="track-toggle tjsv-btn-track" title="Camera tracking (T)">&#x229A; Track</button>
         <div class="frame-display">Frame <span class="tjsv-current-frame">0</span>/<span class="tjsv-total-frames">0</span></div>
     </div>
     <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | T: Track | &uarr;&darr;: Speed</div>
@@ -698,7 +695,7 @@ class ThreeJSViewer {
         this._trackMode = 'off';       // 'off' | 'follow' | 'lookat'
         this._trackLastPos = new THREE.Vector3();
         this._trackHasLastPos = false;
-        this._trackInteractive = false; // true when user pressed F (interactive override)
+        this._trackInteractive = false; // true when user pressed T (interactive override)
         this._tmpTrackPos = new THREE.Vector3();   // reusable scratch vectors
         this._tmpTrackDelta = new THREE.Vector3();
 
@@ -1617,22 +1614,21 @@ class ThreeJSViewer {
 
     _updateTrackingUI() {
         if (!this._btnTrack) return;
-        if (this._trackMode === 'off') {
-            this._btnTrack.classList.remove('active');
-            this._btnTrack.textContent = '\u229A Track';
-        } else {
-            this._btnTrack.classList.add('active');
+        const hasTracking = this._trackTargetId || this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
+        this._btnTrack.style.display = (this._animation && hasTracking) ? '' : 'none';
+        this._btnTrack.classList.toggle('active', this._trackMode !== 'off');
+
+        let title = 'Camera tracking (T)';
+        if (this._trackMode !== 'off') {
             const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
             if (hasChannels && !this._trackInteractive) {
-                this._btnTrack.textContent = 'Camera: scripted';
+                title = 'Camera: scripted (T)';
             } else {
                 const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
-                const shortId = this._trackTargetId && this._trackTargetId.length > 10
-                    ? this._trackTargetId.slice(0, 10) + '\u2026'
-                    : (this._trackTargetId || '');
-                this._btnTrack.textContent = `${modeLabel}: ${shortId}`;
+                title = `${modeLabel}: ${this._trackTargetId || ''} (T)`;
             }
         }
+        this._btnTrack.title = title;
     }
 
     _applyCameraTracking(frameIndex) {

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -694,7 +694,7 @@ class ThreeJSViewer {
 
         // Camera tracking state
         this._trackTargetId = null;
-        this._trackMode = 'off';       // 'off' | 'follow' | 'lookat'
+        this._trackMode = 'off';       // 'off' | 'follow' | 'lookat' | 'scripted'
         this._trackLastPos = new THREE.Vector3();
         this._trackHasLastPos = false;
         this._trackInteractive = false; // true when user pressed T (interactive override)
@@ -1482,7 +1482,7 @@ class ThreeJSViewer {
             this._trackTargetId = animData.camera_lookat;
             this._trackMode = 'lookat';
         } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
-            this._trackMode = 'follow'; // enable so _applyCameraTracking runs
+            this._trackMode = 'scripted';
             this._trackTargetId = null;
         } else {
             this._trackMode = 'off';
@@ -1591,27 +1591,39 @@ class ThreeJSViewer {
 
     _cycleTrackMode() {
         this._trackInteractive = true;
-        if (!this._trackTargetId && this._trackMode === 'off') {
-            this._trackTargetId = this._guessTrackTarget();
+        const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
+
+        if (this._trackMode === 'scripted') {
+            // Scripted → off
+            this._trackMode = 'off';
+        } else if (hasChannels && this._trackMode === 'off' && !this._trackTargetId) {
+            // Off → re-enable scripted (if no object target, only channels)
+            this._trackInteractive = false;
+            this._trackMode = 'scripted';
+        } else {
+            // Object-based: off → follow → lookat → off
+            if (!this._trackTargetId && this._trackMode === 'off') {
+                this._trackTargetId = this._guessTrackTarget();
+            }
+            if (this._trackTargetId) {
+                const modes = ['off', 'follow', 'lookat'];
+                const idx = modes.indexOf(this._trackMode);
+                this._trackMode = modes[(idx + 1) % modes.length];
+            }
         }
-        if (this._trackTargetId || this._animation?.channels?.camera_target || this._animation?.channels?.camera_position) {
-            const modes = ['off', 'follow', 'lookat'];
-            const idx = modes.indexOf(this._trackMode);
-            this._trackMode = modes[(idx + 1) % modes.length];
-            this._trackHasLastPos = false;
-        }
+        this._trackHasLastPos = false;
         this._updateTrackingUI();
     }
 
     _guessTrackTarget() {
         if (!this._animation?.channels?.transforms) return null;
         const ids = this._animation.channels.transforms.ids;
-        const hints = ['nozzle', 'tip', 'tool', 'head', 'effector'];
+        const hints = ['nozzle', 'tip', 'tool', 'effector'];
         for (const hint of hints) {
             const match = ids.find(id => id.toLowerCase().includes(hint));
             if (match) return match;
         }
-        return ids[ids.length - 1];
+        return null;
     }
 
     _updateTrackingUI() {
@@ -1621,14 +1633,11 @@ class ThreeJSViewer {
         this._btnTrack.classList.toggle('active', this._trackMode !== 'off');
 
         let title = 'Camera tracking (T)';
-        if (this._trackMode !== 'off') {
-            const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
-            if (hasChannels && !this._trackInteractive) {
-                title = 'Camera: scripted (T)';
-            } else {
-                const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
-                title = `${modeLabel}: ${this._trackTargetId || ''} (T)`;
-            }
+        if (this._trackMode === 'scripted') {
+            title = 'Camera: scripted (T)';
+        } else if (this._trackMode !== 'off') {
+            const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
+            title = `${modeLabel}: ${this._trackTargetId || ''} (T)`;
         }
         this._btnTrack.title = title;
     }
@@ -1636,8 +1645,8 @@ class ThreeJSViewer {
     _applyCameraTracking(frameIndex) {
         if (this._trackMode === 'off') return;
 
-        // Camera channels (unless interactive override is active)
-        if (!this._trackInteractive && this._animation?.channels) {
+        // Scripted camera channels
+        if (this._trackMode === 'scripted' && this._animation?.channels) {
             const ctCh = this._animation.channels.camera_target;
             const cpCh = this._animation.channels.camera_position;
             if (ctCh || cpCh) {
@@ -2188,6 +2197,8 @@ class ThreeJSViewer {
                                     frames: frames,
                                     markers: data.markers || [],
                                     channels: channels,
+                                    camera_follow: data.camera_follow || null,
+                                    camera_lookat: data.camera_lookat || null,
                                 });
                                 console.log(`  total: ${(performance.now() - t0).toFixed(0)}ms`);
                             } catch (e) {

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -200,7 +200,8 @@
             min-width: 50px;
             text-align: center;
         }
-        .threejs-viewer .loop-toggle {
+        .threejs-viewer .loop-toggle,
+        .threejs-viewer .track-toggle {
             background: #444;
             border: none;
             color: white;
@@ -209,8 +210,10 @@
             cursor: pointer;
             font-size: 12px;
         }
-        .threejs-viewer .loop-toggle:hover { background: #555; }
-        .threejs-viewer .loop-toggle.active { background: #0066cc; }
+        .threejs-viewer .loop-toggle:hover,
+        .threejs-viewer .track-toggle:hover { background: #555; }
+        .threejs-viewer .loop-toggle.active,
+        .threejs-viewer .track-toggle.active { background: #0066cc; }
         .threejs-viewer .frame-display {
             font-family: monospace;
             font-size: 11px;
@@ -452,9 +455,10 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
             <button class="tjsv-btn-faster" title="Faster (&uarr)">+</button>
         </div>
         <button class="loop-toggle active tjsv-btn-loop" title="Toggle loop (L)">&#x27F3; Loop</button>
+        <button class="track-toggle tjsv-btn-track" title="Camera tracking (T)">&#x229A; Track</button>
         <div class="frame-display">Frame <span class="tjsv-current-frame">0</span>/<span class="tjsv-total-frames">0</span></div>
     </div>
-    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
+    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | T: Track | &uarr;&darr;: Speed</div>
 </div>
 `;
 
@@ -558,6 +562,10 @@ function makeChannelApply(viewer) {
                 viewer._setClipTime(ch.ids[i], ch.data[base + i]);
             }
         },
+
+        // No-ops: data is read directly in _applyCameraTracking, not per-object
+        camera_target: () => {},
+        camera_position: () => {},
     };
 }
 
@@ -685,6 +693,15 @@ class ThreeJSViewer {
         // Camera state
         this._isOrtho = false;
 
+        // Camera tracking state
+        this._trackTargetId = null;
+        this._trackMode = 'off';       // 'off' | 'follow' | 'lookat'
+        this._trackLastPos = new THREE.Vector3();
+        this._trackHasLastPos = false;
+        this._trackInteractive = false; // true when user pressed F (interactive override)
+        this._tmpTrackPos = new THREE.Vector3();   // reusable scratch vectors
+        this._tmpTrackDelta = new THREE.Vector3();
+
         // Channel apply functions
         this._CHANNEL_APPLY = makeChannelApply(this);
 
@@ -743,6 +760,7 @@ class ThreeJSViewer {
         this._btnLoop = q('.tjsv-btn-loop');
         this._speedDisplayEl = q('.tjsv-speed-display');
         this._timelineContainer = q('.tjsv-timeline-container');
+        this._btnTrack = q('.tjsv-btn-track');
     }
 
     _initThreeJS() {
@@ -1454,6 +1472,25 @@ class ThreeJSViewer {
         }
 
         this._applyFrame(0);
+
+        // Camera tracking from animation metadata
+        this._trackHasLastPos = false;
+        this._trackInteractive = false;
+        if (animData.camera_follow) {
+            this._trackTargetId = animData.camera_follow;
+            this._trackMode = 'follow';
+        } else if (animData.camera_lookat) {
+            this._trackTargetId = animData.camera_lookat;
+            this._trackMode = 'lookat';
+        } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
+            this._trackMode = 'follow'; // enable so _applyCameraTracking runs
+            this._trackTargetId = null;
+        } else {
+            this._trackMode = 'off';
+            this._trackTargetId = null;
+        }
+        this._updateTrackingUI();
+
         this._animationPlaying = true;
         this._lastAnimationUpdate = performance.now();
         console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
@@ -1469,6 +1506,12 @@ class ThreeJSViewer {
         this._animation = null;
         this._animationPlaying = false;
         this._animControlsEl.classList.remove('visible');
+
+        this._trackMode = 'off';
+        this._trackTargetId = null;
+        this._trackHasLastPos = false;
+        this._trackInteractive = false;
+        this._updateTrackingUI();
     }
 
     _applyFrame(frameIndex) {
@@ -1543,6 +1586,105 @@ class ThreeJSViewer {
                 this._setDrawRange(id, value);
             }
         }
+
+        this._applyCameraTracking(frameIndex);
+    }
+
+    _cycleTrackMode() {
+        this._trackInteractive = true;
+        if (!this._trackTargetId && this._trackMode === 'off') {
+            this._trackTargetId = this._guessTrackTarget();
+        }
+        if (this._trackTargetId || this._animation?.channels?.camera_target || this._animation?.channels?.camera_position) {
+            const modes = ['off', 'follow', 'lookat'];
+            const idx = modes.indexOf(this._trackMode);
+            this._trackMode = modes[(idx + 1) % modes.length];
+            this._trackHasLastPos = false;
+        }
+        this._updateTrackingUI();
+    }
+
+    _guessTrackTarget() {
+        if (!this._animation?.channels?.transforms) return null;
+        const ids = this._animation.channels.transforms.ids;
+        const hints = ['nozzle', 'tip', 'tool', 'head', 'effector'];
+        for (const hint of hints) {
+            const match = ids.find(id => id.toLowerCase().includes(hint));
+            if (match) return match;
+        }
+        return ids[ids.length - 1];
+    }
+
+    _updateTrackingUI() {
+        if (!this._btnTrack) return;
+        if (this._trackMode === 'off') {
+            this._btnTrack.classList.remove('active');
+            this._btnTrack.textContent = '\u229A Track';
+        } else {
+            this._btnTrack.classList.add('active');
+            const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
+            if (hasChannels && !this._trackInteractive) {
+                this._btnTrack.textContent = 'Camera: scripted';
+            } else {
+                const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
+                const shortId = this._trackTargetId && this._trackTargetId.length > 10
+                    ? this._trackTargetId.slice(0, 10) + '\u2026'
+                    : (this._trackTargetId || '');
+                this._btnTrack.textContent = `${modeLabel}: ${shortId}`;
+            }
+        }
+    }
+
+    _applyCameraTracking(frameIndex) {
+        if (this._trackMode === 'off') return;
+
+        // Camera channels (unless interactive override is active)
+        if (!this._trackInteractive && this._animation?.channels) {
+            const ctCh = this._animation.channels.camera_target;
+            const cpCh = this._animation.channels.camera_position;
+            if (ctCh || cpCh) {
+                if (ctCh) {
+                    const base = frameIndex * 3;
+                    this._controls.target.set(
+                        ctCh.data[base], ctCh.data[base + 1], ctCh.data[base + 2]
+                    );
+                }
+                if (cpCh) {
+                    const base = frameIndex * 3;
+                    this._camera.position.set(
+                        cpCh.data[base], cpCh.data[base + 1], cpCh.data[base + 2]
+                    );
+                }
+                return;
+            }
+        }
+
+        // Object-based tracking (follow / lookat)
+        if (!this._trackTargetId) return;
+        const obj = this._objects.get(this._trackTargetId);
+        if (!obj) return;
+
+        obj.updateWorldMatrix(true, false);
+        const targetPos = this._tmpTrackPos;
+        targetPos.setFromMatrixPosition(obj.matrixWorld);
+
+        if (this._trackMode === 'follow') {
+            if (this._trackHasLastPos) {
+                const delta = this._tmpTrackDelta.copy(targetPos).sub(this._trackLastPos);
+                this._controls.target.add(delta);
+                this._camera.position.add(delta);
+            } else {
+                // First frame: snap orbit target, keep camera offset
+                const offset = this._tmpTrackDelta.copy(this._camera.position).sub(this._controls.target);
+                this._controls.target.copy(targetPos);
+                this._camera.position.copy(targetPos).add(offset);
+            }
+        } else if (this._trackMode === 'lookat') {
+            this._controls.target.copy(targetPos);
+        }
+
+        this._trackLastPos.copy(targetPos);
+        this._trackHasLastPos = true;
     }
 
     _getFrameAtTime(time) {
@@ -1702,6 +1844,7 @@ class ThreeJSViewer {
             this._animationLoop = !this._animationLoop;
             this._btnLoop.classList.toggle('active', this._animationLoop);
         });
+        this._btnTrack.addEventListener('click', () => this._cycleTrackMode());
         this.el.querySelector('.tjsv-btn-slower').addEventListener('click', () => this._stepSpeed(-1));
         this.el.querySelector('.tjsv-btn-faster').addEventListener('click', () => this._stepSpeed(1));
 
@@ -1829,6 +1972,9 @@ class ThreeJSViewer {
                 case 'KeyL':
                     this._animationLoop = !this._animationLoop;
                     this._btnLoop.classList.toggle('active', this._animationLoop);
+                    break;
+                case 'KeyT':
+                    this._cycleTrackMode();
                     break;
                 case 'ArrowUp':
                     e.preventDefault();

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -4,6 +4,7 @@
     <div class="toolbar-sep"></div>
     <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane (C)">&#x2702;</button>
     <button class="toolbar-btn tjsv-btn-ortho" title="Orthographic / Perspective (O)">P</button>
+    <button class="toolbar-btn tjsv-btn-track" title="Camera tracking (T)" style="display:none">&#x229A;</button>
 </div>
 
 <div class="tjsv-clipping-panel">
@@ -73,7 +74,6 @@
             <button class="tjsv-btn-faster" title="Faster (&uarr)">+</button>
         </div>
         <button class="loop-toggle active tjsv-btn-loop" title="Toggle loop (L)">&#x27F3; Loop</button>
-        <button class="track-toggle tjsv-btn-track" title="Camera tracking (T)">&#x229A; Track</button>
         <div class="frame-display">Frame <span class="tjsv-current-frame">0</span>/<span class="tjsv-total-frames">0</span></div>
     </div>
     <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | T: Track | &uarr;&darr;: Speed</div>

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -2,9 +2,9 @@
     <div class="tjsv-status-dot disconnected" title="Disconnected"></div>
     <span class="tjsv-status-text">Disconnected</span>
     <div class="toolbar-sep"></div>
-    <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane (C)">&#x2702;</button>
+    <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane">&#x2702; C</button>
     <button class="toolbar-btn tjsv-btn-ortho" title="Orthographic / Perspective (O)">P</button>
-    <button class="toolbar-btn tjsv-btn-track" title="Camera tracking (T)" style="display:none">&#x229A;</button>
+    <button class="toolbar-btn tjsv-btn-track" title="Camera tracking" style="display:none">&#x229A; T</button>
 </div>
 
 <div class="tjsv-clipping-panel">
@@ -76,5 +76,5 @@
         <button class="loop-toggle active tjsv-btn-loop" title="Toggle loop (L)">&#x27F3; Loop</button>
         <div class="frame-display">Frame <span class="tjsv-current-frame">0</span>/<span class="tjsv-total-frames">0</span></div>
     </div>
-    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | T: Track | &uarr;&darr;: Speed</div>
+    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
 </div>

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -73,7 +73,8 @@
             <button class="tjsv-btn-faster" title="Faster (&uarr)">+</button>
         </div>
         <button class="loop-toggle active tjsv-btn-loop" title="Toggle loop (L)">&#x27F3; Loop</button>
+        <button class="track-toggle tjsv-btn-track" title="Camera tracking (T)">&#x229A; Track</button>
         <div class="frame-display">Frame <span class="tjsv-current-frame">0</span>/<span class="tjsv-total-frames">0</span></div>
     </div>
-    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
+    <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | T: Track | &uarr;&darr;: Speed</div>
 </div>

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -189,7 +189,8 @@
     min-width: 50px;
     text-align: center;
 }
-.threejs-viewer .loop-toggle {
+.threejs-viewer .loop-toggle,
+.threejs-viewer .track-toggle {
     background: #444;
     border: none;
     color: white;
@@ -198,8 +199,10 @@
     cursor: pointer;
     font-size: 12px;
 }
-.threejs-viewer .loop-toggle:hover { background: #555; }
-.threejs-viewer .loop-toggle.active { background: #0066cc; }
+.threejs-viewer .loop-toggle:hover,
+.threejs-viewer .track-toggle:hover { background: #555; }
+.threejs-viewer .loop-toggle.active,
+.threejs-viewer .track-toggle.active { background: #0066cc; }
 .threejs-viewer .frame-display {
     font-family: monospace;
     font-size: 11px;

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -47,14 +47,16 @@
     background: none;
     border: none;
     color: #aaa;
-    width: 28px;
+    min-width: 28px;
     height: 28px;
+    padding: 0 6px;
     border-radius: 4px;
     cursor: pointer;
-    font-size: 15px;
+    font-size: 13px;
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 3px;
     transition: background 0.15s, color 0.15s;
 }
 .threejs-viewer .toolbar-btn:hover { background: rgba(255,255,255,0.1); color: white; }

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -189,8 +189,7 @@
     min-width: 50px;
     text-align: center;
 }
-.threejs-viewer .loop-toggle,
-.threejs-viewer .track-toggle {
+.threejs-viewer .loop-toggle {
     background: #444;
     border: none;
     color: white;
@@ -199,10 +198,8 @@
     cursor: pointer;
     font-size: 12px;
 }
-.threejs-viewer .loop-toggle:hover,
-.threejs-viewer .track-toggle:hover { background: #555; }
-.threejs-viewer .loop-toggle.active,
-.threejs-viewer .track-toggle.active { background: #0066cc; }
+.threejs-viewer .loop-toggle:hover { background: #555; }
+.threejs-viewer .loop-toggle.active { background: #0066cc; }
 .threejs-viewer .frame-display {
     font-family: monospace;
     font-size: 11px;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -98,6 +98,10 @@ function makeChannelApply(viewer) {
                 viewer._setClipTime(ch.ids[i], ch.data[base + i]);
             }
         },
+
+        // No-ops: data is read directly in _applyCameraTracking, not per-object
+        camera_target: () => {},
+        camera_position: () => {},
     };
 }
 
@@ -225,6 +229,15 @@ export class ThreeJSViewer {
         // Camera state
         this._isOrtho = false;
 
+        // Camera tracking state
+        this._trackTargetId = null;
+        this._trackMode = 'off';       // 'off' | 'follow' | 'lookat'
+        this._trackLastPos = new THREE.Vector3();
+        this._trackHasLastPos = false;
+        this._trackInteractive = false; // true when user pressed F (interactive override)
+        this._tmpTrackPos = new THREE.Vector3();   // reusable scratch vectors
+        this._tmpTrackDelta = new THREE.Vector3();
+
         // Channel apply functions
         this._CHANNEL_APPLY = makeChannelApply(this);
 
@@ -283,6 +296,7 @@ export class ThreeJSViewer {
         this._btnLoop = q('.tjsv-btn-loop');
         this._speedDisplayEl = q('.tjsv-speed-display');
         this._timelineContainer = q('.tjsv-timeline-container');
+        this._btnTrack = q('.tjsv-btn-track');
     }
 
     _initThreeJS() {
@@ -994,6 +1008,25 @@ export class ThreeJSViewer {
         }
 
         this._applyFrame(0);
+
+        // Camera tracking from animation metadata
+        this._trackHasLastPos = false;
+        this._trackInteractive = false;
+        if (animData.camera_follow) {
+            this._trackTargetId = animData.camera_follow;
+            this._trackMode = 'follow';
+        } else if (animData.camera_lookat) {
+            this._trackTargetId = animData.camera_lookat;
+            this._trackMode = 'lookat';
+        } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
+            this._trackMode = 'follow'; // enable so _applyCameraTracking runs
+            this._trackTargetId = null;
+        } else {
+            this._trackMode = 'off';
+            this._trackTargetId = null;
+        }
+        this._updateTrackingUI();
+
         this._animationPlaying = true;
         this._lastAnimationUpdate = performance.now();
         console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
@@ -1009,6 +1042,12 @@ export class ThreeJSViewer {
         this._animation = null;
         this._animationPlaying = false;
         this._animControlsEl.classList.remove('visible');
+
+        this._trackMode = 'off';
+        this._trackTargetId = null;
+        this._trackHasLastPos = false;
+        this._trackInteractive = false;
+        this._updateTrackingUI();
     }
 
     _applyFrame(frameIndex) {
@@ -1083,6 +1122,105 @@ export class ThreeJSViewer {
                 this._setDrawRange(id, value);
             }
         }
+
+        this._applyCameraTracking(frameIndex);
+    }
+
+    _cycleTrackMode() {
+        this._trackInteractive = true;
+        if (!this._trackTargetId && this._trackMode === 'off') {
+            this._trackTargetId = this._guessTrackTarget();
+        }
+        if (this._trackTargetId || this._animation?.channels?.camera_target || this._animation?.channels?.camera_position) {
+            const modes = ['off', 'follow', 'lookat'];
+            const idx = modes.indexOf(this._trackMode);
+            this._trackMode = modes[(idx + 1) % modes.length];
+            this._trackHasLastPos = false;
+        }
+        this._updateTrackingUI();
+    }
+
+    _guessTrackTarget() {
+        if (!this._animation?.channels?.transforms) return null;
+        const ids = this._animation.channels.transforms.ids;
+        const hints = ['nozzle', 'tip', 'tool', 'head', 'effector'];
+        for (const hint of hints) {
+            const match = ids.find(id => id.toLowerCase().includes(hint));
+            if (match) return match;
+        }
+        return ids[ids.length - 1];
+    }
+
+    _updateTrackingUI() {
+        if (!this._btnTrack) return;
+        if (this._trackMode === 'off') {
+            this._btnTrack.classList.remove('active');
+            this._btnTrack.textContent = '\u229A Track';
+        } else {
+            this._btnTrack.classList.add('active');
+            const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
+            if (hasChannels && !this._trackInteractive) {
+                this._btnTrack.textContent = 'Camera: scripted';
+            } else {
+                const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
+                const shortId = this._trackTargetId && this._trackTargetId.length > 10
+                    ? this._trackTargetId.slice(0, 10) + '\u2026'
+                    : (this._trackTargetId || '');
+                this._btnTrack.textContent = `${modeLabel}: ${shortId}`;
+            }
+        }
+    }
+
+    _applyCameraTracking(frameIndex) {
+        if (this._trackMode === 'off') return;
+
+        // Camera channels (unless interactive override is active)
+        if (!this._trackInteractive && this._animation?.channels) {
+            const ctCh = this._animation.channels.camera_target;
+            const cpCh = this._animation.channels.camera_position;
+            if (ctCh || cpCh) {
+                if (ctCh) {
+                    const base = frameIndex * 3;
+                    this._controls.target.set(
+                        ctCh.data[base], ctCh.data[base + 1], ctCh.data[base + 2]
+                    );
+                }
+                if (cpCh) {
+                    const base = frameIndex * 3;
+                    this._camera.position.set(
+                        cpCh.data[base], cpCh.data[base + 1], cpCh.data[base + 2]
+                    );
+                }
+                return;
+            }
+        }
+
+        // Object-based tracking (follow / lookat)
+        if (!this._trackTargetId) return;
+        const obj = this._objects.get(this._trackTargetId);
+        if (!obj) return;
+
+        obj.updateWorldMatrix(true, false);
+        const targetPos = this._tmpTrackPos;
+        targetPos.setFromMatrixPosition(obj.matrixWorld);
+
+        if (this._trackMode === 'follow') {
+            if (this._trackHasLastPos) {
+                const delta = this._tmpTrackDelta.copy(targetPos).sub(this._trackLastPos);
+                this._controls.target.add(delta);
+                this._camera.position.add(delta);
+            } else {
+                // First frame: snap orbit target, keep camera offset
+                const offset = this._tmpTrackDelta.copy(this._camera.position).sub(this._controls.target);
+                this._controls.target.copy(targetPos);
+                this._camera.position.copy(targetPos).add(offset);
+            }
+        } else if (this._trackMode === 'lookat') {
+            this._controls.target.copy(targetPos);
+        }
+
+        this._trackLastPos.copy(targetPos);
+        this._trackHasLastPos = true;
     }
 
     _getFrameAtTime(time) {
@@ -1242,6 +1380,7 @@ export class ThreeJSViewer {
             this._animationLoop = !this._animationLoop;
             this._btnLoop.classList.toggle('active', this._animationLoop);
         });
+        this._btnTrack.addEventListener('click', () => this._cycleTrackMode());
         this.el.querySelector('.tjsv-btn-slower').addEventListener('click', () => this._stepSpeed(-1));
         this.el.querySelector('.tjsv-btn-faster').addEventListener('click', () => this._stepSpeed(1));
 
@@ -1369,6 +1508,9 @@ export class ThreeJSViewer {
                 case 'KeyL':
                     this._animationLoop = !this._animationLoop;
                     this._btnLoop.classList.toggle('active', this._animationLoop);
+                    break;
+                case 'KeyT':
+                    this._cycleTrackMode();
                     break;
                 case 'ArrowUp':
                     e.preventDefault();

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -234,7 +234,7 @@ export class ThreeJSViewer {
         this._trackMode = 'off';       // 'off' | 'follow' | 'lookat'
         this._trackLastPos = new THREE.Vector3();
         this._trackHasLastPos = false;
-        this._trackInteractive = false; // true when user pressed F (interactive override)
+        this._trackInteractive = false; // true when user pressed T (interactive override)
         this._tmpTrackPos = new THREE.Vector3();   // reusable scratch vectors
         this._tmpTrackDelta = new THREE.Vector3();
 
@@ -1153,22 +1153,21 @@ export class ThreeJSViewer {
 
     _updateTrackingUI() {
         if (!this._btnTrack) return;
-        if (this._trackMode === 'off') {
-            this._btnTrack.classList.remove('active');
-            this._btnTrack.textContent = '\u229A Track';
-        } else {
-            this._btnTrack.classList.add('active');
+        const hasTracking = this._trackTargetId || this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
+        this._btnTrack.style.display = (this._animation && hasTracking) ? '' : 'none';
+        this._btnTrack.classList.toggle('active', this._trackMode !== 'off');
+
+        let title = 'Camera tracking (T)';
+        if (this._trackMode !== 'off') {
             const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
             if (hasChannels && !this._trackInteractive) {
-                this._btnTrack.textContent = 'Camera: scripted';
+                title = 'Camera: scripted (T)';
             } else {
                 const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
-                const shortId = this._trackTargetId && this._trackTargetId.length > 10
-                    ? this._trackTargetId.slice(0, 10) + '\u2026'
-                    : (this._trackTargetId || '');
-                this._btnTrack.textContent = `${modeLabel}: ${shortId}`;
+                title = `${modeLabel}: ${this._trackTargetId || ''} (T)`;
             }
         }
+        this._btnTrack.title = title;
     }
 
     _applyCameraTracking(frameIndex) {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -231,7 +231,7 @@ export class ThreeJSViewer {
 
         // Camera tracking state
         this._trackTargetId = null;
-        this._trackMode = 'off';       // 'off' | 'follow' | 'lookat'
+        this._trackMode = 'off';       // 'off' | 'follow' | 'lookat' | 'scripted'
         this._trackLastPos = new THREE.Vector3();
         this._trackHasLastPos = false;
         this._trackInteractive = false; // true when user pressed T (interactive override)
@@ -1019,7 +1019,7 @@ export class ThreeJSViewer {
             this._trackTargetId = animData.camera_lookat;
             this._trackMode = 'lookat';
         } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
-            this._trackMode = 'follow'; // enable so _applyCameraTracking runs
+            this._trackMode = 'scripted';
             this._trackTargetId = null;
         } else {
             this._trackMode = 'off';
@@ -1128,27 +1128,39 @@ export class ThreeJSViewer {
 
     _cycleTrackMode() {
         this._trackInteractive = true;
-        if (!this._trackTargetId && this._trackMode === 'off') {
-            this._trackTargetId = this._guessTrackTarget();
+        const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
+
+        if (this._trackMode === 'scripted') {
+            // Scripted → off
+            this._trackMode = 'off';
+        } else if (hasChannels && this._trackMode === 'off' && !this._trackTargetId) {
+            // Off → re-enable scripted (if no object target, only channels)
+            this._trackInteractive = false;
+            this._trackMode = 'scripted';
+        } else {
+            // Object-based: off → follow → lookat → off
+            if (!this._trackTargetId && this._trackMode === 'off') {
+                this._trackTargetId = this._guessTrackTarget();
+            }
+            if (this._trackTargetId) {
+                const modes = ['off', 'follow', 'lookat'];
+                const idx = modes.indexOf(this._trackMode);
+                this._trackMode = modes[(idx + 1) % modes.length];
+            }
         }
-        if (this._trackTargetId || this._animation?.channels?.camera_target || this._animation?.channels?.camera_position) {
-            const modes = ['off', 'follow', 'lookat'];
-            const idx = modes.indexOf(this._trackMode);
-            this._trackMode = modes[(idx + 1) % modes.length];
-            this._trackHasLastPos = false;
-        }
+        this._trackHasLastPos = false;
         this._updateTrackingUI();
     }
 
     _guessTrackTarget() {
         if (!this._animation?.channels?.transforms) return null;
         const ids = this._animation.channels.transforms.ids;
-        const hints = ['nozzle', 'tip', 'tool', 'head', 'effector'];
+        const hints = ['nozzle', 'tip', 'tool', 'effector'];
         for (const hint of hints) {
             const match = ids.find(id => id.toLowerCase().includes(hint));
             if (match) return match;
         }
-        return ids[ids.length - 1];
+        return null;
     }
 
     _updateTrackingUI() {
@@ -1158,14 +1170,11 @@ export class ThreeJSViewer {
         this._btnTrack.classList.toggle('active', this._trackMode !== 'off');
 
         let title = 'Camera tracking (T)';
-        if (this._trackMode !== 'off') {
-            const hasChannels = this._animation?.channels?.camera_target || this._animation?.channels?.camera_position;
-            if (hasChannels && !this._trackInteractive) {
-                title = 'Camera: scripted (T)';
-            } else {
-                const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
-                title = `${modeLabel}: ${this._trackTargetId || ''} (T)`;
-            }
+        if (this._trackMode === 'scripted') {
+            title = 'Camera: scripted (T)';
+        } else if (this._trackMode !== 'off') {
+            const modeLabel = this._trackMode === 'follow' ? 'Follow' : 'Look-at';
+            title = `${modeLabel}: ${this._trackTargetId || ''} (T)`;
         }
         this._btnTrack.title = title;
     }
@@ -1173,8 +1182,8 @@ export class ThreeJSViewer {
     _applyCameraTracking(frameIndex) {
         if (this._trackMode === 'off') return;
 
-        // Camera channels (unless interactive override is active)
-        if (!this._trackInteractive && this._animation?.channels) {
+        // Scripted camera channels
+        if (this._trackMode === 'scripted' && this._animation?.channels) {
             const ctCh = this._animation.channels.camera_target;
             const cpCh = this._animation.channels.camera_position;
             if (ctCh || cpCh) {
@@ -1725,6 +1734,8 @@ export class ThreeJSViewer {
                                     frames: frames,
                                     markers: data.markers || [],
                                     channels: channels,
+                                    camera_follow: data.camera_follow || null,
+                                    camera_lookat: data.camera_lookat || null,
                                 });
                                 console.log(`  total: ${(performance.now() - t0).toFixed(0)}ms`);
                             } catch (e) {

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -420,3 +420,70 @@ def test_merge_animation_points_duplicate_timestamps():
     assert len(t5_indices) == 2
     assert combined[t5_indices[0], 4] == pytest.approx(bw)  # full-width first
     assert combined[t5_indices[1], 4] == pytest.approx(0.0)  # cap second
+
+
+# --- Camera tracking tests ---
+
+
+def test_camera_follow():
+    """Test camera_follow metadata on Animation."""
+    anim = Animation(loop=True, camera_follow="nozzle")
+    assert anim.camera_follow == "nozzle"
+    assert anim.camera_lookat is None
+    d = anim.to_dict()
+    assert d["camera_follow"] == "nozzle"
+    assert "camera_lookat" not in d
+
+
+def test_camera_lookat():
+    """Test camera_lookat metadata on Animation."""
+    anim = Animation(loop=True, camera_lookat="nozzle")
+    assert anim.camera_lookat == "nozzle"
+    assert anim.camera_follow is None
+    d = anim.to_dict()
+    assert d["camera_lookat"] == "nozzle"
+    assert "camera_follow" not in d
+
+
+def test_camera_follow_lookat_mutually_exclusive():
+    """Setting both camera_follow and camera_lookat raises ValueError."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Animation(camera_follow="a", camera_lookat="b")
+
+
+def test_camera_no_tracking_to_dict():
+    """to_dict omits camera keys when not set."""
+    anim = Animation()
+    d = anim.to_dict()
+    assert "camera_follow" not in d
+    assert "camera_lookat" not in d
+
+
+def test_set_camera_target():
+    """Test set_camera_target creates a camera_target channel."""
+    anim = Animation()
+    anim.set_frame_times(np.linspace(0, 1, 10))
+    data = np.random.rand(10, 3).astype(np.float32)
+    anim.set_camera_target(data)
+
+    assert len(anim._channels) == 1
+    ch = anim._channels[0]
+    assert ch.name == "camera_target"
+    assert ch.ids == ["__camera__"]
+    assert ch.stride == 3
+    assert ch.dtype == "float32"
+
+
+def test_set_camera_position():
+    """Test set_camera_position creates a camera_position channel."""
+    anim = Animation()
+    anim.set_frame_times(np.linspace(0, 1, 10))
+    data = np.random.rand(10, 3).astype(np.float32)
+    anim.set_camera_position(data)
+
+    assert len(anim._channels) == 1
+    ch = anim._channels[0]
+    assert ch.name == "camera_position"
+    assert ch.ids == ["__camera__"]
+    assert ch.stride == 3
+    assert ch.dtype == "float32"


### PR DESCRIPTION
## Summary

- **Follow mode** (`camera_follow="nozzle"`): orbit target tracks object, camera pans along — user can rotate/zoom freely
- **Look-at mode** (`camera_lookat="nozzle"`): camera stays put, always points at object — user can reposition freely  
- **Camera channels** (`set_camera_target`/`set_camera_position`): per-frame scripted camera via binary channels
- **Interactive override**: T key cycles Off → Follow → Look-at, always wins over animation defaults
- Auto-detect heuristic finds tracking target from transforms channel (looks for "nozzle", "tool", etc.)

### Python API
```python
# Simple
animation = Animation(loop=True, camera_follow="nozzle")

# Scripted
animation.set_camera_target(positions)   # (n_frames, 3) float32
animation.set_camera_position(positions) # (n_frames, 3) float32
```

### Review fixes applied
- Pre-allocated reusable Vector3s (no GC pressure at 60fps)
- Mutual exclusivity validation for camera_follow/camera_lookat
- Combined CSS selectors for loop/track toggles
- Simplified to_dict pattern
- Changed shortcut from F to T (avoids conflict with "focus" in 3D viewers)
- Added 6 unit tests for new Animation fields and methods
- Comment on no-op channel entries

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] `uv run pytest` — 120 tests pass (6 new)
- [x] Manual: `uv run python examples/11_toolpath.py` — verify follow mode tracks nozzle
- [x] Manual: T key cycles Off → Follow → Look-at → Off
- [x] Manual: rotation/zoom preserved in follow mode, camera repositioning works in look-at mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)