### PR TITLE
Add grid API, fix animation cleanup, extend query_scene

### DIFF
--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -861,6 +861,27 @@ class ViewerClient:
             }
         )
 
+    def show_grid(
+        self,
+        visible: bool = True,
+        size: float | None = None,
+        divisions: int | None = None,
+    ) -> None:
+        """Show or hide the ground grid, optionally resizing it.
+
+        Args:
+            visible: Whether the grid is visible.
+            size: Grid size (side length). Applied when both size and
+                divisions are provided.
+            divisions: Number of grid divisions. Applied when both size
+                and divisions are provided.
+        """
+        msg: dict = {"type": "show_grid", "visible": visible}
+        if size is not None and divisions is not None:
+            msg["size"] = size
+            msg["divisions"] = divisions
+        self._send(msg)
+
     def clear(self) -> None:
         """Clear all objects from the scene."""
         self._send({"type": "clear_scene"})
@@ -1049,7 +1070,7 @@ class ViewerClient:
         self._send(header)
 
     def stop_animation(self) -> None:
-        """Stop animation playback and return to real-time mode."""
+        """Stop animation playback, reset draw ranges, and return to real-time mode."""
         self._current_animation = None
         self._send({"type": "stop_animation"})
 
@@ -1072,7 +1093,10 @@ class ViewerClient:
     def query_scene(self, timeout: float = 5.0) -> dict:
         """Query the viewer's scene graph.
 
-        Returns dict of {id: {type, parent, children, visible}}.
+        Returns dict with keys:
+        - Object IDs mapping to {type, parent, children, visible, drawRange}
+        - ``"_animation"`` with ``{playing: bool}``
+        - ``"_grid"`` with ``{visible: bool}``
         """
         request_id = str(uuid.uuid4())
         event = threading.Event()
@@ -1086,7 +1110,12 @@ class ViewerClient:
 
         response = self._responses.pop(request_id, {})
         self._pending_responses.pop(request_id, None)
-        return response.get("tree", {})
+        result = response.get("tree", {})
+        if "animation" in response:
+            result["_animation"] = response["animation"]
+        if "grid" in response:
+            result["_grid"] = response["grid"]
+        return result
 
 
 def viewer(

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -814,9 +814,10 @@ class ThreeJSViewer {
         const ambientLight = new THREE.AmbientLight(0xffffff, 1.5);
         this._scene.add(ambientLight);
 
-        // Grid helper on XY plane (Z-up)
+        // Grid helper on XY plane (Z-up) — hidden by default
         this._gridHelper = new THREE.GridHelper(10, 10);
         this._gridHelper.rotation.x = Math.PI / 2;
+        this._gridHelper.visible = false;
         this._scene.add(this._gridHelper);
 
         // Loaders
@@ -1407,6 +1408,7 @@ class ThreeJSViewer {
     }
 
     _clearScene() {
+        this._resetAnimationState();
         for (const id of this._objects.keys()) {
             this._deleteObject(id);
         }
@@ -1494,6 +1496,17 @@ class ThreeJSViewer {
         console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
     }
 
+    _resetAnimationState() {
+        this._animation = null;
+        this._animationPlaying = false;
+        this._animControlsEl.classList.remove('visible');
+        this._trackMode = 'off';
+        this._trackTargetId = null;
+        this._trackHasLastPos = false;
+        this._trackInteractive = false;
+        this._updateTrackingUI();
+    }
+
     _stopAnimation() {
         this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
         for (const [id, baselineVisible] of this._baselineVisibility) {
@@ -1501,15 +1514,11 @@ class ThreeJSViewer {
             if (obj) obj.visible = baselineVisible;
         }
         this._baselineVisibility.clear();
-        this._animation = null;
-        this._animationPlaying = false;
-        this._animControlsEl.classList.remove('visible');
-
-        this._trackMode = 'off';
-        this._trackTargetId = null;
-        this._trackHasLastPos = false;
-        this._trackInteractive = false;
-        this._updateTrackingUI();
+        // Reset draw ranges to full
+        for (const id of this._objects.keys()) {
+            this._setDrawRange(id, 1.0);
+        }
+        this._resetAnimationState();
     }
 
     _applyFrame(frameIndex) {
@@ -2104,6 +2113,17 @@ class ThreeJSViewer {
                     case 'query_scene': {
                         const tree = {};
                         for (const [id, obj] of this._objects) {
+                            let drawRange = 1.0;
+                            const geom = obj.geometry;
+                            if (geom) {
+                                if (obj.userData.isPolyline) {
+                                    const max = obj.userData.maxInstanceCount;
+                                    drawRange = max > 0 ? (geom.instanceCount / max) : 1.0;
+                                } else if (obj.userData.isMesh) {
+                                    const total = obj.userData.totalIndexCount;
+                                    drawRange = total > 0 ? (geom.drawRange.count / total) : 1.0;
+                                }
+                            }
                             tree[id] = {
                                 type: obj.type,
                                 parent: obj.parent?.userData?.id || null,
@@ -2111,17 +2131,24 @@ class ThreeJSViewer {
                                     .filter(c => c.userData?.id)
                                     .map(c => c.userData.id),
                                 visible: obj.visible,
+                                drawRange: drawRange,
                             };
                         }
                         this._ws.send(JSON.stringify({
                             type: 'query_scene_response',
                             requestId: data.requestId,
                             tree: tree,
+                            animation: { playing: this._animationPlaying },
+                            grid: { visible: this._gridHelper.visible },
                         }));
                         break;
                     }
                     case 'load_animation':
                         this._loadAnimation(data.animation);
+                        break;
+                    case 'clear_animation':  // alias for stop_animation
+                    case 'stop_animation':
+                        this._stopAnimation();
                         break;
                     case 'load_animation_http':
                         this._onFetchStart();
@@ -2360,9 +2387,6 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'stop_animation':
-                        this._stopAnimation();
-                        break;
                     case 'set_clip_time':
                         this._setClipTime(data.id, data.time);
                         break;
@@ -2428,6 +2452,19 @@ class ThreeJSViewer {
                         break;
                     case 'set_clipping_defaults':
                         this._clipDefaults = { normal: data.normal, distance: data.distance };
+                        break;
+                    case 'show_grid':
+                        this._gridHelper.visible = !!data.visible;
+                        if (data.size != null && data.divisions != null) {
+                            const parent = this._gridHelper.parent;
+                            parent.remove(this._gridHelper);
+                            this._gridHelper.geometry.dispose();
+                            this._gridHelper.material.dispose();
+                            this._gridHelper = new THREE.GridHelper(data.size, data.divisions);
+                            this._gridHelper.rotation.x = Math.PI / 2;
+                            this._gridHelper.visible = !!data.visible;
+                            parent.add(this._gridHelper);
+                        }
                         break;
                     case 'mark_assets_complete':
                         this._assetsComplete = true;

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1499,6 +1499,7 @@ class ThreeJSViewer {
     _resetAnimationState() {
         this._animation = null;
         this._animationPlaying = false;
+        this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
         this._trackMode = 'off';
         this._trackTargetId = null;
@@ -1513,7 +1514,6 @@ class ThreeJSViewer {
             const obj = this._objects.get(id);
             if (obj) obj.visible = baselineVisible;
         }
-        this._baselineVisibility.clear();
         // Reset draw ranges to full
         for (const id of this._objects.keys()) {
             this._setDrawRange(id, 1.0);
@@ -2146,7 +2146,6 @@ class ThreeJSViewer {
                     case 'load_animation':
                         this._loadAnimation(data.animation);
                         break;
-                    case 'clear_animation':  // alias for stop_animation
                     case 'stop_animation':
                         this._stopAnimation();
                         break;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -1036,6 +1036,7 @@ export class ThreeJSViewer {
     _resetAnimationState() {
         this._animation = null;
         this._animationPlaying = false;
+        this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
         this._trackMode = 'off';
         this._trackTargetId = null;
@@ -1050,7 +1051,6 @@ export class ThreeJSViewer {
             const obj = this._objects.get(id);
             if (obj) obj.visible = baselineVisible;
         }
-        this._baselineVisibility.clear();
         // Reset draw ranges to full
         for (const id of this._objects.keys()) {
             this._setDrawRange(id, 1.0);
@@ -1683,7 +1683,6 @@ export class ThreeJSViewer {
                     case 'load_animation':
                         this._loadAnimation(data.animation);
                         break;
-                    case 'clear_animation':  // alias for stop_animation
                     case 'stop_animation':
                         this._stopAnimation();
                         break;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -351,9 +351,10 @@ export class ThreeJSViewer {
         const ambientLight = new THREE.AmbientLight(0xffffff, 1.5);
         this._scene.add(ambientLight);
 
-        // Grid helper on XY plane (Z-up)
+        // Grid helper on XY plane (Z-up) — hidden by default
         this._gridHelper = new THREE.GridHelper(10, 10);
         this._gridHelper.rotation.x = Math.PI / 2;
+        this._gridHelper.visible = false;
         this._scene.add(this._gridHelper);
 
         // Loaders
@@ -944,6 +945,7 @@ export class ThreeJSViewer {
     }
 
     _clearScene() {
+        this._resetAnimationState();
         for (const id of this._objects.keys()) {
             this._deleteObject(id);
         }
@@ -1031,6 +1033,17 @@ export class ThreeJSViewer {
         console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
     }
 
+    _resetAnimationState() {
+        this._animation = null;
+        this._animationPlaying = false;
+        this._animControlsEl.classList.remove('visible');
+        this._trackMode = 'off';
+        this._trackTargetId = null;
+        this._trackHasLastPos = false;
+        this._trackInteractive = false;
+        this._updateTrackingUI();
+    }
+
     _stopAnimation() {
         this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
         for (const [id, baselineVisible] of this._baselineVisibility) {
@@ -1038,15 +1051,11 @@ export class ThreeJSViewer {
             if (obj) obj.visible = baselineVisible;
         }
         this._baselineVisibility.clear();
-        this._animation = null;
-        this._animationPlaying = false;
-        this._animControlsEl.classList.remove('visible');
-
-        this._trackMode = 'off';
-        this._trackTargetId = null;
-        this._trackHasLastPos = false;
-        this._trackInteractive = false;
-        this._updateTrackingUI();
+        // Reset draw ranges to full
+        for (const id of this._objects.keys()) {
+            this._setDrawRange(id, 1.0);
+        }
+        this._resetAnimationState();
     }
 
     _applyFrame(frameIndex) {
@@ -1641,6 +1650,17 @@ export class ThreeJSViewer {
                     case 'query_scene': {
                         const tree = {};
                         for (const [id, obj] of this._objects) {
+                            let drawRange = 1.0;
+                            const geom = obj.geometry;
+                            if (geom) {
+                                if (obj.userData.isPolyline) {
+                                    const max = obj.userData.maxInstanceCount;
+                                    drawRange = max > 0 ? (geom.instanceCount / max) : 1.0;
+                                } else if (obj.userData.isMesh) {
+                                    const total = obj.userData.totalIndexCount;
+                                    drawRange = total > 0 ? (geom.drawRange.count / total) : 1.0;
+                                }
+                            }
                             tree[id] = {
                                 type: obj.type,
                                 parent: obj.parent?.userData?.id || null,
@@ -1648,17 +1668,24 @@ export class ThreeJSViewer {
                                     .filter(c => c.userData?.id)
                                     .map(c => c.userData.id),
                                 visible: obj.visible,
+                                drawRange: drawRange,
                             };
                         }
                         this._ws.send(JSON.stringify({
                             type: 'query_scene_response',
                             requestId: data.requestId,
                             tree: tree,
+                            animation: { playing: this._animationPlaying },
+                            grid: { visible: this._gridHelper.visible },
                         }));
                         break;
                     }
                     case 'load_animation':
                         this._loadAnimation(data.animation);
+                        break;
+                    case 'clear_animation':  // alias for stop_animation
+                    case 'stop_animation':
+                        this._stopAnimation();
                         break;
                     case 'load_animation_http':
                         this._onFetchStart();
@@ -1897,9 +1924,6 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'stop_animation':
-                        this._stopAnimation();
-                        break;
                     case 'set_clip_time':
                         this._setClipTime(data.id, data.time);
                         break;
@@ -1965,6 +1989,19 @@ export class ThreeJSViewer {
                         break;
                     case 'set_clipping_defaults':
                         this._clipDefaults = { normal: data.normal, distance: data.distance };
+                        break;
+                    case 'show_grid':
+                        this._gridHelper.visible = !!data.visible;
+                        if (data.size != null && data.divisions != null) {
+                            const parent = this._gridHelper.parent;
+                            parent.remove(this._gridHelper);
+                            this._gridHelper.geometry.dispose();
+                            this._gridHelper.material.dispose();
+                            this._gridHelper = new THREE.GridHelper(data.size, data.divisions);
+                            this._gridHelper.rotation.x = Math.PI / 2;
+                            this._gridHelper.visible = !!data.visible;
+                            parent.add(this._gridHelper);
+                        }
                         break;
                     case 'mark_assets_complete':
                         this._assetsComplete = true;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4,6 +4,8 @@ import time
 
 import pytest
 
+from threejs_viewer import Animation, Frame
+
 
 @pytest.mark.browser
 def test_viewer_connects(viewer_client, viewer_page):
@@ -64,4 +66,77 @@ def test_clear_scene(viewer_client, viewer_page):
     viewer_client.clear()
     time.sleep(0.1)
     tree = viewer_client.query_scene()
-    assert tree == {}
+    # Only metadata keys should remain (no user objects)
+    assert "a" not in tree
+    assert "b" not in tree
+
+
+@pytest.mark.browser
+def test_stop_animation_resets_draw_range(viewer_client, viewer_page):
+    """stop_animation() resets draw ranges to full."""
+    viewer_client.add_box("box1")
+    time.sleep(0.1)
+    anim = Animation(
+        frames=[
+            Frame(time=0, transforms={}, draw_ranges={"box1": 0.5}),
+            Frame(time=1, transforms={}, draw_ranges={"box1": 0.5}),
+        ],
+        loop=False,
+    )
+    viewer_client.load_animation(anim)
+    # Wait for async HTTP animation load to complete
+    for _ in range(20):
+        time.sleep(0.1)
+        tree = viewer_client.query_scene()
+        if tree["_animation"]["playing"]:
+            break
+    assert tree["_animation"]["playing"] is True, "Animation did not start"
+    viewer_client.stop_animation()
+    time.sleep(0.1)
+    tree = viewer_client.query_scene()
+    assert tree["box1"]["drawRange"] == 1.0
+
+
+@pytest.mark.browser
+def test_clear_resets_animation_state(viewer_client, viewer_page):
+    """clear() resets animation state."""
+    viewer_client.add_box("obj1")
+    time.sleep(0.1)
+    anim = Animation(
+        frames=[
+            Frame(time=0, transforms={}),
+            Frame(time=1, transforms={}),
+        ],
+        loop=True,
+    )
+    viewer_client.load_animation(anim)
+    # Wait for async HTTP animation load to complete
+    for _ in range(20):
+        time.sleep(0.1)
+        tree = viewer_client.query_scene()
+        if tree["_animation"]["playing"]:
+            break
+    assert tree["_animation"]["playing"] is True, "Animation did not start"
+    viewer_client.clear()
+    time.sleep(0.2)
+    tree = viewer_client.query_scene()
+    assert tree["_animation"]["playing"] is False
+
+
+@pytest.mark.browser
+def test_show_grid(viewer_client, viewer_page):
+    """show_grid() toggles grid visibility."""
+    time.sleep(0.1)
+    tree = viewer_client.query_scene()
+    # Grid is hidden by default
+    assert tree["_grid"]["visible"] is False
+
+    viewer_client.show_grid(visible=True)
+    time.sleep(0.1)
+    tree = viewer_client.query_scene()
+    assert tree["_grid"]["visible"] is True
+
+    viewer_client.show_grid(visible=False)
+    time.sleep(0.1)
+    tree = viewer_client.query_scene()
+    assert tree["_grid"]["visible"] is False

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2,6 +2,7 @@
 
 import time
 
+import numpy as np
 import pytest
 
 from threejs_viewer import Animation, Frame
@@ -74,12 +75,15 @@ def test_clear_scene(viewer_client, viewer_page):
 @pytest.mark.browser
 def test_stop_animation_resets_draw_range(viewer_client, viewer_page):
     """stop_animation() resets draw ranges to full."""
-    viewer_client.add_box("box1")
-    time.sleep(0.1)
+    # Use a real mesh so draw_range metadata (userData.isMesh, totalIndexCount) is set
+    positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    indices = np.array([0, 1, 2], dtype=np.uint32)
+    viewer_client.add_mesh("m1", positions, indices)
+    time.sleep(0.3)  # wait for HTTP fetch of binary mesh data
     anim = Animation(
         frames=[
-            Frame(time=0, transforms={}, draw_ranges={"box1": 0.5}),
-            Frame(time=1, transforms={}, draw_ranges={"box1": 0.5}),
+            Frame(time=0, transforms={}, draw_ranges={"m1": 0.5}),
+            Frame(time=1, transforms={}, draw_ranges={"m1": 0.5}),
         ],
         loop=False,
     )
@@ -94,7 +98,7 @@ def test_stop_animation_resets_draw_range(viewer_client, viewer_page):
     viewer_client.stop_animation()
     time.sleep(0.1)
     tree = viewer_client.query_scene()
-    assert tree["box1"]["drawRange"] == 1.0
+    assert tree["m1"]["drawRange"] == 1.0
 
 
 @pytest.mark.browser


### PR DESCRIPTION
## Summary
- **Grid API**: `show_grid(visible, size, divisions)` — toggles/resizes the ground grid (hidden by default). Properly disposes old Three.js geometry on resize.
- **Animation cleanup**: `stop_animation()` resets draw ranges to 1.0 so bead meshes don't stay partially drawn. `clear()` now resets animation state so stale animations don't reference deleted objects.
- **query_scene extensions**: Response now includes per-object `drawRange`, `_animation.playing`, and `_grid.visible` — enables proper browser integration testing.
- **3 new browser tests**: draw range reset on stop, clear resets animation state, grid toggle.

## Motivation
ribweaver's panel slicer has a step-based workflow where going back from animation (step 4) to static toolpath (step 3) left stale animation state — the bead stayed partially drawn and animation controls remained visible. There was no clean way to reset to static display. The grid was also only removable by reaching into private `_gridHelper`/`_scene` internals.

## Test plan
- [x] All 123 tests pass (120 unit + 3 new browser integration)
- [x] Linting clean (`ruff check` + `ruff format --check`)
- [ ] Manual test: load animation with draw_ranges, stop it, verify full mesh visible
- [ ] Manual test: `viewer.show_grid(True, 20, 20)` then `viewer.show_grid(False)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)