### PR TITLE
Fix async race conditions and optimize animation channel refs

### DIFF
--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -1072,7 +1072,10 @@ class ViewerClient:
     def query_scene(self, timeout: float = 5.0) -> dict:
         """Query the viewer's scene graph.
 
-        Returns dict of {id: {type, parent, children, visible}}.
+        Returns dict with keys:
+
+        - Object IDs mapping to ``{type, parent, children, visible}``
+        - ``"_pending_fetches"`` — number of in-flight HTTP fetches (int)
         """
         request_id = str(uuid.uuid4())
         event = threading.Event()
@@ -1086,7 +1089,9 @@ class ViewerClient:
 
         response = self._responses.pop(request_id, {})
         self._pending_responses.pop(request_id, None)
-        return response.get("tree", {})
+        result = response.get("tree", {})
+        result["_pending_fetches"] = response.get("pending_fetches", 0)
+        return result
 
 
 def viewer(

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -541,7 +541,16 @@ function makeChannelApply(viewer) {
         draw_ranges(ch, refs, base) {
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setDrawRange(ch.ids[i], ch.data[base + i]);
+                let obj = refs[i];
+                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                if (obj) {
+                    const value = ch.data[base + i];
+                    if (obj.userData.isPolyline) {
+                        obj.geometry.instanceCount = Math.round(value * obj.userData.maxInstanceCount);
+                    } else if (obj.userData.isMesh) {
+                        obj.geometry.setDrawRange(0, Math.round(value * obj.userData.totalIndexCount));
+                    }
+                }
             }
         },
 
@@ -558,7 +567,9 @@ function makeChannelApply(viewer) {
         clip_times(ch, refs, base) {
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setClipTime(ch.ids[i], ch.data[base + i]);
+                let mixer = refs[i];
+                if (!mixer || !mixer.setTime) { mixer = viewer._mixers.get(ch.ids[i]); if (mixer) refs[i] = mixer; }
+                if (mixer) mixer.setTime(ch.data[base + i]);
             }
         },
 
@@ -660,6 +671,8 @@ class ThreeJSViewer {
         this._objects = new Map();
         this._mixers = new Map();
         this._pendingFetches = 0;
+        this._sceneGeneration = 0;
+        this._animGeneration = 0;
         this._assetsComplete = false;
         this._ws = null;
         this._reconnectTimeout = null;
@@ -1407,6 +1420,7 @@ class ThreeJSViewer {
     }
 
     _clearScene() {
+        this._sceneGeneration++;
         for (const id of this._objects.keys()) {
             this._deleteObject(id);
         }
@@ -1422,6 +1436,7 @@ class ThreeJSViewer {
     // ========== Animation ==========
 
     _loadAnimation(animData) {
+        this._animGeneration++;
         this._animation = animData;
         this._animationTime = 0;
         this._animationPlaying = false;
@@ -2017,6 +2032,8 @@ class ThreeJSViewer {
                 this._statusDot.title = 'Connected';
                 this._statusText.textContent = 'Connected';
                 this._pendingFetches = 0;
+                this._sceneGeneration++;
+                this._animGeneration++;
                 this._assetsComplete = false;
                 this._ws.send(JSON.stringify({ type: 'hello', viewer_version: VIEWER_VERSION }));
             };
@@ -2117,19 +2134,26 @@ class ThreeJSViewer {
                             type: 'query_scene_response',
                             requestId: data.requestId,
                             tree: tree,
+                            pending_fetches: this._pendingFetches,
                         }));
                         break;
                     }
                     case 'load_animation':
                         this._loadAnimation(data.animation);
                         break;
-                    case 'load_animation_http':
+                    case 'load_animation_http': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
+                        const capturedAnim = this._animGeneration;
                         (async () => {
                             try {
                                 const t0 = performance.now();
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene || this._animGeneration !== capturedAnim) {
+                                    console.log('Discarding stale animation fetch');
+                                    return;
+                                }
                                 const t1 = performance.now();
                                 console.log(`HTTP animation fetch: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB in ${(t1 - t0).toFixed(0)}ms`);
 
@@ -2207,12 +2231,18 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_model_binary':
+                    }
+                    case 'add_model_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const meshBytes = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale model fetch');
+                                    return;
+                                }
                                 const blob = new Blob([meshBytes]);
                                 const blobUrl = URL.createObjectURL(blob);
                                 console.log(`Loading model ${data.id} (${data.format}) via HTTP`);
@@ -2233,12 +2263,18 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_polyline_binary':
+                    }
+                    case 'add_polyline_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale polyline fetch');
+                                    return;
+                                }
                                 const rawData = new Uint8Array(buffer);
                                 const numPoints = data.numPoints || (rawData.length / 12);
                                 const positionBytes = numPoints * 12;
@@ -2293,12 +2329,18 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_mesh_binary':
+                    }
+                    case 'add_mesh_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale mesh fetch');
+                                    return;
+                                }
                                 const nv = data.numVertices;
                                 const ni = data.numIndices;
 
@@ -2360,6 +2402,7 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
+                    }
                     case 'stop_animation':
                         this._stopAnimation();
                         break;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -78,7 +78,16 @@ function makeChannelApply(viewer) {
         draw_ranges(ch, refs, base) {
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setDrawRange(ch.ids[i], ch.data[base + i]);
+                let obj = refs[i];
+                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                if (obj) {
+                    const value = ch.data[base + i];
+                    if (obj.userData.isPolyline) {
+                        obj.geometry.instanceCount = Math.round(value * obj.userData.maxInstanceCount);
+                    } else if (obj.userData.isMesh) {
+                        obj.geometry.setDrawRange(0, Math.round(value * obj.userData.totalIndexCount));
+                    }
+                }
             }
         },
 
@@ -95,7 +104,9 @@ function makeChannelApply(viewer) {
         clip_times(ch, refs, base) {
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setClipTime(ch.ids[i], ch.data[base + i]);
+                let mixer = refs[i];
+                if (!mixer || !mixer.setTime) { mixer = viewer._mixers.get(ch.ids[i]); if (mixer) refs[i] = mixer; }
+                if (mixer) mixer.setTime(ch.data[base + i]);
             }
         },
 
@@ -197,6 +208,8 @@ export class ThreeJSViewer {
         this._objects = new Map();
         this._mixers = new Map();
         this._pendingFetches = 0;
+        this._sceneGeneration = 0;
+        this._animGeneration = 0;
         this._assetsComplete = false;
         this._ws = null;
         this._reconnectTimeout = null;
@@ -944,6 +957,7 @@ export class ThreeJSViewer {
     }
 
     _clearScene() {
+        this._sceneGeneration++;
         for (const id of this._objects.keys()) {
             this._deleteObject(id);
         }
@@ -959,6 +973,7 @@ export class ThreeJSViewer {
     // ========== Animation ==========
 
     _loadAnimation(animData) {
+        this._animGeneration++;
         this._animation = animData;
         this._animationTime = 0;
         this._animationPlaying = false;
@@ -1554,6 +1569,8 @@ export class ThreeJSViewer {
                 this._statusDot.title = 'Connected';
                 this._statusText.textContent = 'Connected';
                 this._pendingFetches = 0;
+                this._sceneGeneration++;
+                this._animGeneration++;
                 this._assetsComplete = false;
                 this._ws.send(JSON.stringify({ type: 'hello', viewer_version: VIEWER_VERSION }));
             };
@@ -1654,19 +1671,26 @@ export class ThreeJSViewer {
                             type: 'query_scene_response',
                             requestId: data.requestId,
                             tree: tree,
+                            pending_fetches: this._pendingFetches,
                         }));
                         break;
                     }
                     case 'load_animation':
                         this._loadAnimation(data.animation);
                         break;
-                    case 'load_animation_http':
+                    case 'load_animation_http': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
+                        const capturedAnim = this._animGeneration;
                         (async () => {
                             try {
                                 const t0 = performance.now();
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene || this._animGeneration !== capturedAnim) {
+                                    console.log('Discarding stale animation fetch');
+                                    return;
+                                }
                                 const t1 = performance.now();
                                 console.log(`HTTP animation fetch: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB in ${(t1 - t0).toFixed(0)}ms`);
 
@@ -1744,12 +1768,18 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_model_binary':
+                    }
+                    case 'add_model_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const meshBytes = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale model fetch');
+                                    return;
+                                }
                                 const blob = new Blob([meshBytes]);
                                 const blobUrl = URL.createObjectURL(blob);
                                 console.log(`Loading model ${data.id} (${data.format}) via HTTP`);
@@ -1770,12 +1800,18 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_polyline_binary':
+                    }
+                    case 'add_polyline_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale polyline fetch');
+                                    return;
+                                }
                                 const rawData = new Uint8Array(buffer);
                                 const numPoints = data.numPoints || (rawData.length / 12);
                                 const positionBytes = numPoints * 12;
@@ -1830,12 +1866,18 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_mesh_binary':
+                    }
+                    case 'add_mesh_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale mesh fetch');
+                                    return;
+                                }
                                 const nv = data.numVertices;
                                 const ni = data.numIndices;
 
@@ -1897,6 +1939,7 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
+                    }
                     case 'stop_animation':
                         this._stopAnimation();
                         break;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -64,4 +64,6 @@ def test_clear_scene(viewer_client, viewer_page):
     viewer_client.clear()
     time.sleep(0.1)
     tree = viewer_client.query_scene()
-    assert tree == {}
+    # Only metadata keys should remain (no user objects)
+    assert "a" not in tree
+    assert "b" not in tree

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -387,7 +387,7 @@ def test_query_scene_sends_correct_message(client):
     assert len(sent) == 1
     assert sent[0]["type"] == "query_scene"
     assert "requestId" in sent[0]
-    assert result == {}
+    assert result == {"_pending_fetches": 0}
 
 
 # === Clipping plane ===


### PR DESCRIPTION
## Summary
- **Refs cache for draw_ranges/clip_times**: These two channel apply functions were the only ones doing `Map.get()` lookups every animation frame instead of using the `refs` cache. Now consistent with transforms/colors/visibility/opacity handlers.
- **Generation counters**: Added `_sceneGeneration` (incremented on `_clearScene` and reconnect) and `_animGeneration` (incremented on `_loadAnimation` and reconnect). All 4 async HTTP fetch handlers (`load_animation_http`, `add_model_binary`, `add_polyline_binary`, `add_mesh_binary`) capture the generation before `await fetch()` and discard the result if it changed — prevents stale fetches from corrupting cleared/replaced state.
- **`_pending_fetches` in query_scene**: Backend can now check `tree["_pending_fetches"]` to know if objects are still loading, without needing `wait_for_assets()`.

## Motivation
Audit found that `clear_scene` during in-flight HTTP fetches silently added objects to a cleared scene, and two rapid `load_animation_http` calls could race (slower fetch overwrites newer animation). The refs cache inconsistency was flagged by TS diagnostics.

## Test plan
- [x] All 120 tests pass
- [x] Linting clean
- [ ] Manual: send `clear_scene` while a large model is loading, verify it doesn't appear
- [ ] Manual: rapidly switch animations, verify correct one plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)