### PR TITLE
Add grid API, fix animation cleanup, guard async races, extend query_scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.0.18
+
+### New features
+
+- **Grid API** — `show_grid(visible, size, divisions)` to toggle/resize the ground grid (hidden by default)
+- **`add_mesh` transform** — `position`, `rotation`, `scale`, and `matrix` parameters for placing meshes directly
+- **`query_scene` restructured** — returns `{"objects": {...}, "meta": {...}}` with per-object `drawRange` and viewer metadata (`animation.playing`, `grid.visible`, `pending_fetches`). **Breaking**: replaces flat dict.
+
+### Bug fixes
+
+- **WebSocket fetch probe removed** — eliminates 404 spam on FastAPI/non-HTTP WS routes and ~30s initial connection delay
+- **Animation cleanup** — `stop_animation()` resets draw ranges to full; `clear()` resets animation state
+- **Async race protection** — generation counters guard all HTTP fetch handlers against stale completion after `clear_scene`, animation replacement, or reconnect
+- **Channel refs cache staleness** — object/mixer refs invalidated via generation counters on mutation, preventing stale updates after `delete_object` or ID reuse
+- **Pending fetches accounting** — counter clamped to 0 to prevent negative values from stale fetch completions after reconnect
+- **Animation generation guards** — `_stopAnimation()` and `load_animation_http` increment `_animGeneration` to discard in-flight loads
+
 ## 0.0.17
 
 ### New features

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -600,6 +600,10 @@ class ViewerClient:
         metalness: float = 0.1,
         roughness: float = 0.8,
         parent: Optional[str] = None,
+        position: Optional[list] = None,
+        rotation: Optional[list] = None,
+        scale: Optional[list] = None,
+        matrix: Optional[list] = None,
     ) -> None:
         """
         Add a pre-built triangle mesh to the scene.
@@ -614,6 +618,11 @@ class ViewerClient:
             opacity: Material opacity (0.0 = invisible, 1.0 = fully opaque)
             metalness: PBR metalness (0-1)
             roughness: PBR roughness (0-1)
+            parent: Optional parent group id
+            position: [x, y, z] position
+            rotation: [x, y, z] Euler rotation in radians
+            scale: [x, y, z] scale
+            matrix: Column-major 4x4 transform matrix (overrides position/rotation/scale)
         """
         positions = np.ascontiguousarray(positions, dtype=np.float32).reshape(-1)
         indices = np.ascontiguousarray(indices, dtype=np.uint32).reshape(-1)
@@ -644,6 +653,17 @@ class ViewerClient:
         }
         if parent:
             header["parent"] = parent
+        if matrix:
+            header["transform"] = {"matrix": matrix}
+        elif position or rotation or scale:
+            transform = {}
+            if position:
+                transform["position"] = position
+            if rotation:
+                transform["rotation"] = rotation
+            if scale:
+                transform["scale"] = scale
+            header["transform"] = transform
         self._send_binary(header, b"".join(parts))
 
     def _apply_colormap(
@@ -861,6 +881,27 @@ class ViewerClient:
             }
         )
 
+    def show_grid(
+        self,
+        visible: bool = True,
+        size: float | None = None,
+        divisions: int | None = None,
+    ) -> None:
+        """Show or hide the ground grid, optionally resizing it.
+
+        Args:
+            visible: Whether the grid is visible.
+            size: Grid size (side length). Applied when both size and
+                divisions are provided.
+            divisions: Number of grid divisions. Applied when both size
+                and divisions are provided.
+        """
+        msg: dict = {"type": "show_grid", "visible": visible}
+        if size is not None and divisions is not None:
+            msg["size"] = size
+            msg["divisions"] = divisions
+        self._send(msg)
+
     def clear(self) -> None:
         """Clear all objects from the scene."""
         self._send({"type": "clear_scene"})
@@ -1049,7 +1090,7 @@ class ViewerClient:
         self._send(header)
 
     def stop_animation(self) -> None:
-        """Stop animation playback and return to real-time mode."""
+        """Stop animation playback, reset draw ranges, and return to real-time mode."""
         self._current_animation = None
         self._send({"type": "stop_animation"})
 
@@ -1072,7 +1113,12 @@ class ViewerClient:
     def query_scene(self, timeout: float = 5.0) -> dict:
         """Query the viewer's scene graph.
 
-        Returns dict of {id: {type, parent, children, visible}}.
+        Returns ``{"objects": {id: {...}}, "meta": {...}}``:
+
+        - ``objects`` — dict of object IDs to
+          ``{type, parent, children, visible, drawRange}``
+        - ``meta`` — ``{animation: {playing}, grid: {visible},
+          pending_fetches: int}``
         """
         request_id = str(uuid.uuid4())
         event = threading.Event()
@@ -1086,7 +1132,10 @@ class ViewerClient:
 
         response = self._responses.pop(request_id, {})
         self._pending_responses.pop(request_id, None)
-        return response.get("tree", {})
+        return {
+            "objects": response.get("tree", {}),
+            "meta": response.get("meta", {}),
+        }
 
 
 def viewer(

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -493,17 +493,26 @@ const CLIP_AXIS_NORMALS = {
 };
 
 
+// Refresh cached refs array when the object/mixer map has changed.
+// Called at most once per frame per channel (guarded by generation check).
+function refreshRefs(refs, ids, map) {
+    for (let i = 0; i < ids.length; i++) {
+        refs[i] = map.get(ids[i]) || null;
+    }
+}
+
 // Channel apply functions — keyed by channel name
 function makeChannelApply(viewer) {
     return {
         transforms(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+                for (let i = 0; i < refs.length; i++) { if (refs[i]) refs[i].matrixAutoUpdate = false; }
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                let obj = refs[i];
-                if (!obj) {
-                    obj = viewer._objects.get(ch.ids[i]);
-                    if (obj) { refs[i] = obj; obj.matrixAutoUpdate = false; }
-                }
+                const obj = refs[i];
                 if (obj) {
                     obj.matrix.fromArray(ch.data, base + i * 16);
                     obj.matrixWorldNeedsUpdate = true;
@@ -512,13 +521,16 @@ function makeChannelApply(viewer) {
         },
 
         colors(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             const colormap = ch.colormap;
             for (let i = 0; i < nObj; i++) {
                 const raw = ch.data[base + i];
                 const color = colormap ? colormap[raw] : raw;
-                let obj = refs[i];
-                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                const obj = refs[i];
                 if (obj) {
                     obj.traverse(child => {
                         if (!child.material) return;
@@ -530,35 +542,58 @@ function makeChannelApply(viewer) {
         },
 
         visibility(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                let obj = refs[i];
-                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                const obj = refs[i];
                 if (obj) obj.visible = (ch.data[base + i] === 1);
             }
         },
 
         draw_ranges(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setDrawRange(ch.ids[i], ch.data[base + i]);
+                const obj = refs[i];
+                if (obj) {
+                    const value = ch.data[base + i];
+                    if (obj.userData.isPolyline) {
+                        obj.geometry.instanceCount = Math.round(value * obj.userData.maxInstanceCount);
+                    } else if (obj.userData.isMesh) {
+                        obj.geometry.setDrawRange(0, Math.round(value * obj.userData.totalIndexCount));
+                    }
+                }
             }
         },
 
         opacity(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
                 const val = ch.data[base + i];
-                let obj = refs[i];
-                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                const obj = refs[i];
                 if (obj) applyOpacity(obj, val);
             }
         },
 
         clip_times(ch, refs, base) {
+            if (ch._mixerGen !== viewer._mixerGeneration) {
+                refreshRefs(refs, ch.ids, viewer._mixers);
+                ch._mixerGen = viewer._mixerGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setClipTime(ch.ids[i], ch.data[base + i]);
+                const mixer = refs[i];
+                if (mixer && mixer.setTime) mixer.setTime(ch.data[base + i]);
             }
         },
 
@@ -659,7 +694,11 @@ class ThreeJSViewer {
         // State
         this._objects = new Map();
         this._mixers = new Map();
+        this._objGeneration = 0;
+        this._mixerGeneration = 0;
         this._pendingFetches = 0;
+        this._sceneGeneration = 0;
+        this._animGeneration = 0;
         this._assetsComplete = false;
         this._ws = null;
         this._reconnectTimeout = null;
@@ -814,9 +853,10 @@ class ThreeJSViewer {
         const ambientLight = new THREE.AmbientLight(0xffffff, 1.5);
         this._scene.add(ambientLight);
 
-        // Grid helper on XY plane (Z-up)
+        // Grid helper on XY plane (Z-up) — hidden by default
         this._gridHelper = new THREE.GridHelper(10, 10);
         this._gridHelper.rotation.x = Math.PI / 2;
+        this._gridHelper.visible = false;
         this._scene.add(this._gridHelper);
 
         // Loaders
@@ -1290,6 +1330,7 @@ class ThreeJSViewer {
                     }
                     mixer.setTime(0);
                     this._mixers.set(id, mixer);
+                    this._mixerGeneration++;
                     console.log(`Model ${id}: ${result.animations.length} animation clip(s) available`);
                 }
             } catch (e) {
@@ -1305,6 +1346,7 @@ class ThreeJSViewer {
             if (objData.visible === false) obj.visible = false;
             this._addToParentOrScene(obj, parentId);
             this._objects.set(id, obj);
+            this._objGeneration++;
             if (this._clipEnabled) this._applyClipToObject(obj);
         }
     }
@@ -1380,13 +1422,14 @@ class ThreeJSViewer {
             for (const childId of childIds) {
                 this._objects.delete(childId);
                 const childMixer = this._mixers.get(childId);
-                if (childMixer) { childMixer.stopAllAction(); this._mixers.delete(childId); }
+                if (childMixer) { childMixer.stopAllAction(); this._mixers.delete(childId); this._mixerGeneration++; }
             }
             if (obj.parent) obj.parent.remove(obj);
             this._objects.delete(id);
+            this._objGeneration++;
             this._sceneBoundsDirty = true;
             const mixer = this._mixers.get(id);
-            if (mixer) { mixer.stopAllAction(); this._mixers.delete(id); }
+            if (mixer) { mixer.stopAllAction(); this._mixers.delete(id); this._mixerGeneration++; }
             obj.traverse((child) => {
                 if (child.userData.blobUrl) URL.revokeObjectURL(child.userData.blobUrl);
                 if (child.geometry) child.geometry.dispose();
@@ -1407,6 +1450,8 @@ class ThreeJSViewer {
     }
 
     _clearScene() {
+        this._sceneGeneration++;
+        this._resetAnimationState();
         for (const id of this._objects.keys()) {
             this._deleteObject(id);
         }
@@ -1422,6 +1467,7 @@ class ThreeJSViewer {
     // ========== Animation ==========
 
     _loadAnimation(animData) {
+        this._animGeneration++;
         this._animation = animData;
         this._animationTime = 0;
         this._animationPlaying = false;
@@ -1494,22 +1540,30 @@ class ThreeJSViewer {
         console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
     }
 
-    _stopAnimation() {
-        this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
-        for (const [id, baselineVisible] of this._baselineVisibility) {
-            const obj = this._objects.get(id);
-            if (obj) obj.visible = baselineVisible;
-        }
-        this._baselineVisibility.clear();
+    _resetAnimationState() {
         this._animation = null;
         this._animationPlaying = false;
+        this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
-
         this._trackMode = 'off';
         this._trackTargetId = null;
         this._trackHasLastPos = false;
         this._trackInteractive = false;
         this._updateTrackingUI();
+    }
+
+    _stopAnimation() {
+        this._animGeneration++;
+        this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
+        for (const [id, baselineVisible] of this._baselineVisibility) {
+            const obj = this._objects.get(id);
+            if (obj) obj.visible = baselineVisible;
+        }
+        // Reset draw ranges to full
+        for (const id of this._objects.keys()) {
+            this._setDrawRange(id, 1.0);
+        }
+        this._resetAnimationState();
     }
 
     _applyFrame(frameIndex) {
@@ -1768,7 +1822,7 @@ class ThreeJSViewer {
 
     _onFetchStart() { this._pendingFetches++; }
     _onFetchEnd() {
-        this._pendingFetches--;
+        this._pendingFetches = Math.max(0, this._pendingFetches - 1);
         this._maybeNotifyAssetsLoaded();
     }
 
@@ -1998,17 +2052,8 @@ class ThreeJSViewer {
     // ========== WebSocket ==========
 
     connect() {
-        // Derive HTTP URL from WS URL for the fetch probe
-        const httpUrl = this._wsUrl.replace(/^ws(s?):/, 'http$1:');
-
-        const doConnect = async () => {
+        const doConnect = () => {
             if (this._destroyed) return;
-            try {
-                await fetch(httpUrl, { mode: 'no-cors' });
-            } catch {
-                this._reconnectTimeout = setTimeout(doConnect, 1000);
-                return;
-            }
 
             this._ws = new WebSocket(this._wsUrl);
 
@@ -2016,7 +2061,12 @@ class ThreeJSViewer {
                 this._statusDot.className = 'tjsv-status-dot connected';
                 this._statusDot.title = 'Connected';
                 this._statusText.textContent = 'Connected';
-                this._pendingFetches = 0;
+                // Don't reset _pendingFetches to 0: in-flight HTTP fetches from the
+                // previous connection may still complete and run _onFetchEnd(), which
+                // would drive the counter negative. Generation counters ensure stale
+                // fetches are discarded; let their finally blocks balance the count.
+                this._sceneGeneration++;
+                this._animGeneration++;
                 this._assetsComplete = false;
                 this._ws.send(JSON.stringify({ type: 'hello', viewer_version: VIEWER_VERSION }));
             };
@@ -2059,6 +2109,7 @@ class ThreeJSViewer {
                         if (data.visible === false) group.visible = false;
                         this._addToParentOrScene(group, data.parent);
                         this._objects.set(data.id, group);
+                        this._objGeneration++;
                         break;
                     }
                     case 'add_object':
@@ -2104,6 +2155,20 @@ class ThreeJSViewer {
                     case 'query_scene': {
                         const tree = {};
                         for (const [id, obj] of this._objects) {
+                            let drawRange = 1.0;
+                            const geom = obj.geometry;
+                            if (geom) {
+                                if (obj.userData.isPolyline) {
+                                    const max = obj.userData.maxInstanceCount;
+                                    drawRange = max > 0 ? Math.min(geom.instanceCount / max, 1.0) : 1.0;
+                                } else if (obj.userData.isMesh) {
+                                    const total = obj.userData.totalIndexCount;
+                                    if (total > 0) {
+                                        const cnt = geom.drawRange.count;
+                                        drawRange = Number.isFinite(cnt) ? Math.min(cnt / total, 1.0) : 1.0;
+                                    }
+                                }
+                            }
                             tree[id] = {
                                 type: obj.type,
                                 parent: obj.parent?.userData?.id || null,
@@ -2111,25 +2176,37 @@ class ThreeJSViewer {
                                     .filter(c => c.userData?.id)
                                     .map(c => c.userData.id),
                                 visible: obj.visible,
+                                drawRange: drawRange,
                             };
                         }
                         this._ws.send(JSON.stringify({
                             type: 'query_scene_response',
                             requestId: data.requestId,
                             tree: tree,
+                            meta: {
+                                animation: { playing: this._animationPlaying },
+                                grid: { visible: this._gridHelper.visible },
+                                pending_fetches: this._pendingFetches,
+                            },
                         }));
                         break;
                     }
                     case 'load_animation':
                         this._loadAnimation(data.animation);
                         break;
-                    case 'load_animation_http':
+                    case 'load_animation_http': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
+                        const capturedAnim = ++this._animGeneration;
                         (async () => {
                             try {
                                 const t0 = performance.now();
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene || this._animGeneration !== capturedAnim) {
+                                    console.log('Discarding stale animation fetch');
+                                    return;
+                                }
                                 const t1 = performance.now();
                                 console.log(`HTTP animation fetch: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB in ${(t1 - t0).toFixed(0)}ms`);
 
@@ -2207,12 +2284,18 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_model_binary':
+                    }
+                    case 'add_model_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const meshBytes = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale model fetch');
+                                    return;
+                                }
                                 const blob = new Blob([meshBytes]);
                                 const blobUrl = URL.createObjectURL(blob);
                                 console.log(`Loading model ${data.id} (${data.format}) via HTTP`);
@@ -2233,12 +2316,18 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_polyline_binary':
+                    }
+                    case 'add_polyline_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale polyline fetch');
+                                    return;
+                                }
                                 const rawData = new Uint8Array(buffer);
                                 const numPoints = data.numPoints || (rawData.length / 12);
                                 const positionBytes = numPoints * 12;
@@ -2286,6 +2375,7 @@ class ThreeJSViewer {
                                 line.userData.maxInstanceCount = numPoints - 1;
                                 this._addToParentOrScene(line, data.parent);
                                 this._objects.set(data.id, line);
+                                this._objGeneration++;
                             } catch (e) {
                                 console.error(`Error creating polyline via HTTP:`, e);
                             } finally {
@@ -2293,12 +2383,18 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_mesh_binary':
+                    }
+                    case 'add_mesh_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale mesh fetch');
+                                    return;
+                                }
                                 const nv = data.numVertices;
                                 const ni = data.numIndices;
 
@@ -2352,6 +2448,8 @@ class ThreeJSViewer {
                                 mesh.userData.totalIndexCount = ni;
                                 this._addToParentOrScene(mesh, data.parent);
                                 this._objects.set(data.id, mesh);
+                                this._objGeneration++;
+                                if (data.transform) this._applyTransform(mesh, data.transform);
                                 console.log(`Created mesh ${data.id}: ${nv} verts, ${(ni / 3)|0} tris`);
                             } catch (e) {
                                 console.error(`Error creating mesh:`, e);
@@ -2360,6 +2458,7 @@ class ThreeJSViewer {
                             }
                         })();
                         break;
+                    }
                     case 'stop_animation':
                         this._stopAnimation();
                         break;
@@ -2428,6 +2527,19 @@ class ThreeJSViewer {
                         break;
                     case 'set_clipping_defaults':
                         this._clipDefaults = { normal: data.normal, distance: data.distance };
+                        break;
+                    case 'show_grid':
+                        this._gridHelper.visible = !!data.visible;
+                        if (data.size != null && data.divisions != null) {
+                            const parent = this._gridHelper.parent;
+                            parent.remove(this._gridHelper);
+                            this._gridHelper.geometry.dispose();
+                            this._gridHelper.material.dispose();
+                            this._gridHelper = new THREE.GridHelper(data.size, data.divisions);
+                            this._gridHelper.rotation.x = Math.PI / 2;
+                            this._gridHelper.visible = !!data.visible;
+                            parent.add(this._gridHelper);
+                        }
                         break;
                     case 'mark_assets_complete':
                         this._assetsComplete = true;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -30,17 +30,26 @@ const CLIP_AXIS_NORMALS = {
 };
 
 
+// Refresh cached refs array when the object/mixer map has changed.
+// Called at most once per frame per channel (guarded by generation check).
+function refreshRefs(refs, ids, map) {
+    for (let i = 0; i < ids.length; i++) {
+        refs[i] = map.get(ids[i]) || null;
+    }
+}
+
 // Channel apply functions — keyed by channel name
 function makeChannelApply(viewer) {
     return {
         transforms(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+                for (let i = 0; i < refs.length; i++) { if (refs[i]) refs[i].matrixAutoUpdate = false; }
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                let obj = refs[i];
-                if (!obj) {
-                    obj = viewer._objects.get(ch.ids[i]);
-                    if (obj) { refs[i] = obj; obj.matrixAutoUpdate = false; }
-                }
+                const obj = refs[i];
                 if (obj) {
                     obj.matrix.fromArray(ch.data, base + i * 16);
                     obj.matrixWorldNeedsUpdate = true;
@@ -49,13 +58,16 @@ function makeChannelApply(viewer) {
         },
 
         colors(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             const colormap = ch.colormap;
             for (let i = 0; i < nObj; i++) {
                 const raw = ch.data[base + i];
                 const color = colormap ? colormap[raw] : raw;
-                let obj = refs[i];
-                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                const obj = refs[i];
                 if (obj) {
                     obj.traverse(child => {
                         if (!child.material) return;
@@ -67,35 +79,58 @@ function makeChannelApply(viewer) {
         },
 
         visibility(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                let obj = refs[i];
-                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                const obj = refs[i];
                 if (obj) obj.visible = (ch.data[base + i] === 1);
             }
         },
 
         draw_ranges(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setDrawRange(ch.ids[i], ch.data[base + i]);
+                const obj = refs[i];
+                if (obj) {
+                    const value = ch.data[base + i];
+                    if (obj.userData.isPolyline) {
+                        obj.geometry.instanceCount = Math.round(value * obj.userData.maxInstanceCount);
+                    } else if (obj.userData.isMesh) {
+                        obj.geometry.setDrawRange(0, Math.round(value * obj.userData.totalIndexCount));
+                    }
+                }
             }
         },
 
         opacity(ch, refs, base) {
+            if (ch._objGen !== viewer._objGeneration) {
+                refreshRefs(refs, ch.ids, viewer._objects);
+                ch._objGen = viewer._objGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
                 const val = ch.data[base + i];
-                let obj = refs[i];
-                if (!obj) { obj = viewer._objects.get(ch.ids[i]); if (obj) refs[i] = obj; }
+                const obj = refs[i];
                 if (obj) applyOpacity(obj, val);
             }
         },
 
         clip_times(ch, refs, base) {
+            if (ch._mixerGen !== viewer._mixerGeneration) {
+                refreshRefs(refs, ch.ids, viewer._mixers);
+                ch._mixerGen = viewer._mixerGeneration;
+            }
             const nObj = ch.ids.length;
             for (let i = 0; i < nObj; i++) {
-                viewer._setClipTime(ch.ids[i], ch.data[base + i]);
+                const mixer = refs[i];
+                if (mixer && mixer.setTime) mixer.setTime(ch.data[base + i]);
             }
         },
 
@@ -196,7 +231,11 @@ export class ThreeJSViewer {
         // State
         this._objects = new Map();
         this._mixers = new Map();
+        this._objGeneration = 0;
+        this._mixerGeneration = 0;
         this._pendingFetches = 0;
+        this._sceneGeneration = 0;
+        this._animGeneration = 0;
         this._assetsComplete = false;
         this._ws = null;
         this._reconnectTimeout = null;
@@ -351,9 +390,10 @@ export class ThreeJSViewer {
         const ambientLight = new THREE.AmbientLight(0xffffff, 1.5);
         this._scene.add(ambientLight);
 
-        // Grid helper on XY plane (Z-up)
+        // Grid helper on XY plane (Z-up) — hidden by default
         this._gridHelper = new THREE.GridHelper(10, 10);
         this._gridHelper.rotation.x = Math.PI / 2;
+        this._gridHelper.visible = false;
         this._scene.add(this._gridHelper);
 
         // Loaders
@@ -827,6 +867,7 @@ export class ThreeJSViewer {
                     }
                     mixer.setTime(0);
                     this._mixers.set(id, mixer);
+                    this._mixerGeneration++;
                     console.log(`Model ${id}: ${result.animations.length} animation clip(s) available`);
                 }
             } catch (e) {
@@ -842,6 +883,7 @@ export class ThreeJSViewer {
             if (objData.visible === false) obj.visible = false;
             this._addToParentOrScene(obj, parentId);
             this._objects.set(id, obj);
+            this._objGeneration++;
             if (this._clipEnabled) this._applyClipToObject(obj);
         }
     }
@@ -917,13 +959,14 @@ export class ThreeJSViewer {
             for (const childId of childIds) {
                 this._objects.delete(childId);
                 const childMixer = this._mixers.get(childId);
-                if (childMixer) { childMixer.stopAllAction(); this._mixers.delete(childId); }
+                if (childMixer) { childMixer.stopAllAction(); this._mixers.delete(childId); this._mixerGeneration++; }
             }
             if (obj.parent) obj.parent.remove(obj);
             this._objects.delete(id);
+            this._objGeneration++;
             this._sceneBoundsDirty = true;
             const mixer = this._mixers.get(id);
-            if (mixer) { mixer.stopAllAction(); this._mixers.delete(id); }
+            if (mixer) { mixer.stopAllAction(); this._mixers.delete(id); this._mixerGeneration++; }
             obj.traverse((child) => {
                 if (child.userData.blobUrl) URL.revokeObjectURL(child.userData.blobUrl);
                 if (child.geometry) child.geometry.dispose();
@@ -944,6 +987,8 @@ export class ThreeJSViewer {
     }
 
     _clearScene() {
+        this._sceneGeneration++;
+        this._resetAnimationState();
         for (const id of this._objects.keys()) {
             this._deleteObject(id);
         }
@@ -959,6 +1004,7 @@ export class ThreeJSViewer {
     // ========== Animation ==========
 
     _loadAnimation(animData) {
+        this._animGeneration++;
         this._animation = animData;
         this._animationTime = 0;
         this._animationPlaying = false;
@@ -1031,22 +1077,30 @@ export class ThreeJSViewer {
         console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
     }
 
-    _stopAnimation() {
-        this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
-        for (const [id, baselineVisible] of this._baselineVisibility) {
-            const obj = this._objects.get(id);
-            if (obj) obj.visible = baselineVisible;
-        }
-        this._baselineVisibility.clear();
+    _resetAnimationState() {
         this._animation = null;
         this._animationPlaying = false;
+        this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
-
         this._trackMode = 'off';
         this._trackTargetId = null;
         this._trackHasLastPos = false;
         this._trackInteractive = false;
         this._updateTrackingUI();
+    }
+
+    _stopAnimation() {
+        this._animGeneration++;
+        this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
+        for (const [id, baselineVisible] of this._baselineVisibility) {
+            const obj = this._objects.get(id);
+            if (obj) obj.visible = baselineVisible;
+        }
+        // Reset draw ranges to full
+        for (const id of this._objects.keys()) {
+            this._setDrawRange(id, 1.0);
+        }
+        this._resetAnimationState();
     }
 
     _applyFrame(frameIndex) {
@@ -1305,7 +1359,7 @@ export class ThreeJSViewer {
 
     _onFetchStart() { this._pendingFetches++; }
     _onFetchEnd() {
-        this._pendingFetches--;
+        this._pendingFetches = Math.max(0, this._pendingFetches - 1);
         this._maybeNotifyAssetsLoaded();
     }
 
@@ -1535,17 +1589,8 @@ export class ThreeJSViewer {
     // ========== WebSocket ==========
 
     connect() {
-        // Derive HTTP URL from WS URL for the fetch probe
-        const httpUrl = this._wsUrl.replace(/^ws(s?):/, 'http$1:');
-
-        const doConnect = async () => {
+        const doConnect = () => {
             if (this._destroyed) return;
-            try {
-                await fetch(httpUrl, { mode: 'no-cors' });
-            } catch {
-                this._reconnectTimeout = setTimeout(doConnect, 1000);
-                return;
-            }
 
             this._ws = new WebSocket(this._wsUrl);
 
@@ -1553,7 +1598,12 @@ export class ThreeJSViewer {
                 this._statusDot.className = 'tjsv-status-dot connected';
                 this._statusDot.title = 'Connected';
                 this._statusText.textContent = 'Connected';
-                this._pendingFetches = 0;
+                // Don't reset _pendingFetches to 0: in-flight HTTP fetches from the
+                // previous connection may still complete and run _onFetchEnd(), which
+                // would drive the counter negative. Generation counters ensure stale
+                // fetches are discarded; let their finally blocks balance the count.
+                this._sceneGeneration++;
+                this._animGeneration++;
                 this._assetsComplete = false;
                 this._ws.send(JSON.stringify({ type: 'hello', viewer_version: VIEWER_VERSION }));
             };
@@ -1596,6 +1646,7 @@ export class ThreeJSViewer {
                         if (data.visible === false) group.visible = false;
                         this._addToParentOrScene(group, data.parent);
                         this._objects.set(data.id, group);
+                        this._objGeneration++;
                         break;
                     }
                     case 'add_object':
@@ -1641,6 +1692,20 @@ export class ThreeJSViewer {
                     case 'query_scene': {
                         const tree = {};
                         for (const [id, obj] of this._objects) {
+                            let drawRange = 1.0;
+                            const geom = obj.geometry;
+                            if (geom) {
+                                if (obj.userData.isPolyline) {
+                                    const max = obj.userData.maxInstanceCount;
+                                    drawRange = max > 0 ? Math.min(geom.instanceCount / max, 1.0) : 1.0;
+                                } else if (obj.userData.isMesh) {
+                                    const total = obj.userData.totalIndexCount;
+                                    if (total > 0) {
+                                        const cnt = geom.drawRange.count;
+                                        drawRange = Number.isFinite(cnt) ? Math.min(cnt / total, 1.0) : 1.0;
+                                    }
+                                }
+                            }
                             tree[id] = {
                                 type: obj.type,
                                 parent: obj.parent?.userData?.id || null,
@@ -1648,25 +1713,37 @@ export class ThreeJSViewer {
                                     .filter(c => c.userData?.id)
                                     .map(c => c.userData.id),
                                 visible: obj.visible,
+                                drawRange: drawRange,
                             };
                         }
                         this._ws.send(JSON.stringify({
                             type: 'query_scene_response',
                             requestId: data.requestId,
                             tree: tree,
+                            meta: {
+                                animation: { playing: this._animationPlaying },
+                                grid: { visible: this._gridHelper.visible },
+                                pending_fetches: this._pendingFetches,
+                            },
                         }));
                         break;
                     }
                     case 'load_animation':
                         this._loadAnimation(data.animation);
                         break;
-                    case 'load_animation_http':
+                    case 'load_animation_http': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
+                        const capturedAnim = ++this._animGeneration;
                         (async () => {
                             try {
                                 const t0 = performance.now();
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene || this._animGeneration !== capturedAnim) {
+                                    console.log('Discarding stale animation fetch');
+                                    return;
+                                }
                                 const t1 = performance.now();
                                 console.log(`HTTP animation fetch: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB in ${(t1 - t0).toFixed(0)}ms`);
 
@@ -1744,12 +1821,18 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_model_binary':
+                    }
+                    case 'add_model_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const meshBytes = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale model fetch');
+                                    return;
+                                }
                                 const blob = new Blob([meshBytes]);
                                 const blobUrl = URL.createObjectURL(blob);
                                 console.log(`Loading model ${data.id} (${data.format}) via HTTP`);
@@ -1770,12 +1853,18 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_polyline_binary':
+                    }
+                    case 'add_polyline_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale polyline fetch');
+                                    return;
+                                }
                                 const rawData = new Uint8Array(buffer);
                                 const numPoints = data.numPoints || (rawData.length / 12);
                                 const positionBytes = numPoints * 12;
@@ -1823,6 +1912,7 @@ export class ThreeJSViewer {
                                 line.userData.maxInstanceCount = numPoints - 1;
                                 this._addToParentOrScene(line, data.parent);
                                 this._objects.set(data.id, line);
+                                this._objGeneration++;
                             } catch (e) {
                                 console.error(`Error creating polyline via HTTP:`, e);
                             } finally {
@@ -1830,12 +1920,18 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
-                    case 'add_mesh_binary':
+                    }
+                    case 'add_mesh_binary': {
                         this._onFetchStart();
+                        const capturedScene = this._sceneGeneration;
                         (async () => {
                             try {
                                 const resp = await fetch(data.blob_url);
                                 const buffer = await resp.arrayBuffer();
+                                if (this._sceneGeneration !== capturedScene) {
+                                    console.log('Discarding stale mesh fetch');
+                                    return;
+                                }
                                 const nv = data.numVertices;
                                 const ni = data.numIndices;
 
@@ -1889,6 +1985,8 @@ export class ThreeJSViewer {
                                 mesh.userData.totalIndexCount = ni;
                                 this._addToParentOrScene(mesh, data.parent);
                                 this._objects.set(data.id, mesh);
+                                this._objGeneration++;
+                                if (data.transform) this._applyTransform(mesh, data.transform);
                                 console.log(`Created mesh ${data.id}: ${nv} verts, ${(ni / 3)|0} tris`);
                             } catch (e) {
                                 console.error(`Error creating mesh:`, e);
@@ -1897,6 +1995,7 @@ export class ThreeJSViewer {
                             }
                         })();
                         break;
+                    }
                     case 'stop_animation':
                         this._stopAnimation();
                         break;
@@ -1965,6 +2064,19 @@ export class ThreeJSViewer {
                         break;
                     case 'set_clipping_defaults':
                         this._clipDefaults = { normal: data.normal, distance: data.distance };
+                        break;
+                    case 'show_grid':
+                        this._gridHelper.visible = !!data.visible;
+                        if (data.size != null && data.divisions != null) {
+                            const parent = this._gridHelper.parent;
+                            parent.remove(this._gridHelper);
+                            this._gridHelper.geometry.dispose();
+                            this._gridHelper.material.dispose();
+                            this._gridHelper = new THREE.GridHelper(data.size, data.divisions);
+                            this._gridHelper.rotation.x = Math.PI / 2;
+                            this._gridHelper.visible = !!data.visible;
+                            parent.add(this._gridHelper);
+                        }
                         break;
                     case 'mark_assets_complete':
                         this._assetsComplete = true;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2,7 +2,10 @@
 
 import time
 
+import numpy as np
 import pytest
+
+from threejs_viewer import Animation, Frame
 
 
 @pytest.mark.browser
@@ -16,9 +19,9 @@ def test_add_box_appears_in_scene(viewer_client, viewer_page):
     """Adding a box from Python creates it in the browser scene graph."""
     viewer_client.add_box("mybox")
     time.sleep(0.1)
-    tree = viewer_client.query_scene()
-    assert "mybox" in tree
-    assert tree["mybox"]["type"] == "Mesh"
+    result = viewer_client.query_scene()
+    assert "mybox" in result["objects"]
+    assert result["objects"]["mybox"]["type"] == "Mesh"
 
 
 @pytest.mark.browser
@@ -27,10 +30,10 @@ def test_grouping(viewer_client, viewer_page):
     viewer_client.add_group("arm")
     viewer_client.add_box("joint", parent="arm")
     time.sleep(0.1)
-    tree = viewer_client.query_scene()
-    assert tree["arm"]["type"] == "Group"
-    assert "joint" in tree["arm"]["children"]
-    assert tree["joint"]["parent"] == "arm"
+    objects = viewer_client.query_scene()["objects"]
+    assert objects["arm"]["type"] == "Group"
+    assert "joint" in objects["arm"]["children"]
+    assert objects["joint"]["parent"] == "arm"
 
 
 @pytest.mark.browser
@@ -40,8 +43,8 @@ def test_delete_object(viewer_client, viewer_page):
     time.sleep(0.05)
     viewer_client.delete("s1")
     time.sleep(0.1)
-    tree = viewer_client.query_scene()
-    assert "s1" not in tree
+    objects = viewer_client.query_scene()["objects"]
+    assert "s1" not in objects
 
 
 @pytest.mark.browser
@@ -51,8 +54,8 @@ def test_visibility(viewer_client, viewer_page):
     time.sleep(0.05)
     viewer_client.set_visible("v1", False)
     time.sleep(0.1)
-    tree = viewer_client.query_scene()
-    assert tree["v1"]["visible"] is False
+    objects = viewer_client.query_scene()["objects"]
+    assert objects["v1"]["visible"] is False
 
 
 @pytest.mark.browser
@@ -63,5 +66,80 @@ def test_clear_scene(viewer_client, viewer_page):
     time.sleep(0.05)
     viewer_client.clear()
     time.sleep(0.1)
-    tree = viewer_client.query_scene()
-    assert tree == {}
+    objects = viewer_client.query_scene()["objects"]
+    assert "a" not in objects
+    assert "b" not in objects
+
+
+@pytest.mark.browser
+def test_stop_animation_resets_draw_range(viewer_client, viewer_page):
+    """stop_animation() resets draw ranges to full."""
+    # Use a real mesh so draw_range metadata (userData.isMesh, totalIndexCount) is set
+    positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    indices = np.array([0, 1, 2], dtype=np.uint32)
+    viewer_client.add_mesh("m1", positions, indices)
+    time.sleep(0.3)  # wait for HTTP fetch of binary mesh data
+    anim = Animation(
+        frames=[
+            Frame(time=0, transforms={}, draw_ranges={"m1": 0.5}),
+            Frame(time=1, transforms={}, draw_ranges={"m1": 0.5}),
+        ],
+        loop=False,
+    )
+    viewer_client.load_animation(anim)
+    # Wait for async HTTP animation load to complete
+    for _ in range(20):
+        time.sleep(0.1)
+        result = viewer_client.query_scene()
+        if result["meta"]["animation"]["playing"]:
+            break
+    assert result["meta"]["animation"]["playing"] is True, "Animation did not start"
+    viewer_client.stop_animation()
+    time.sleep(0.1)
+    result = viewer_client.query_scene()
+    assert result["objects"]["m1"]["drawRange"] == 1.0
+
+
+@pytest.mark.browser
+def test_clear_resets_animation_state(viewer_client, viewer_page):
+    """clear() resets animation state."""
+    viewer_client.add_box("obj1")
+    time.sleep(0.1)
+    anim = Animation(
+        frames=[
+            Frame(time=0, transforms={}),
+            Frame(time=1, transforms={}),
+        ],
+        loop=True,
+    )
+    viewer_client.load_animation(anim)
+    # Wait for async HTTP animation load to complete
+    for _ in range(20):
+        time.sleep(0.1)
+        result = viewer_client.query_scene()
+        if result["meta"]["animation"]["playing"]:
+            break
+    assert result["meta"]["animation"]["playing"] is True, "Animation did not start"
+    viewer_client.clear()
+    time.sleep(0.2)
+    result = viewer_client.query_scene()
+    assert result["meta"]["animation"]["playing"] is False
+
+
+@pytest.mark.browser
+def test_show_grid(viewer_client, viewer_page):
+    """show_grid() toggles grid visibility."""
+    time.sleep(0.1)
+    meta = viewer_client.query_scene()["meta"]
+    # Grid is hidden by default
+    assert meta["grid"]["visible"] is False
+
+    viewer_client.show_grid(visible=True)
+    time.sleep(0.1)
+    meta = viewer_client.query_scene()["meta"]
+    assert meta["grid"]["visible"] is True
+
+    viewer_client.show_grid(visible=False)
+    time.sleep(0.1)
+    meta = viewer_client.query_scene()["meta"]
+    assert meta["grid"]["visible"] is False

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -238,6 +238,31 @@ def test_add_mesh_opacity_default_is_one(client):
     assert header["opacity"] == 1.0
 
 
+def test_add_mesh_with_position(client):
+    pos = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    idx = np.array([0, 1, 2], dtype=np.uint32)
+    client.add_mesh("m", pos, idx, position=[1, 2, 3])
+    header, _ = client._binary_messages[0]
+    assert header["transform"] == {"position": [1, 2, 3]}
+
+
+def test_add_mesh_with_matrix(client):
+    pos = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    idx = np.array([0, 1, 2], dtype=np.uint32)
+    mat = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 6, 7, 1]
+    client.add_mesh("m", pos, idx, matrix=mat)
+    header, _ = client._binary_messages[0]
+    assert header["transform"] == {"matrix": mat}
+
+
+def test_add_mesh_no_transform(client):
+    pos = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+    idx = np.array([0, 1, 2], dtype=np.uint32)
+    client.add_mesh("m", pos, idx)
+    header, _ = client._binary_messages[0]
+    assert "transform" not in header
+
+
 # === Toolpath.to_mesh + add_mesh ===
 
 
@@ -387,7 +412,7 @@ def test_query_scene_sends_correct_message(client):
     assert len(sent) == 1
     assert sent[0]["type"] == "query_scene"
     assert "requestId" in sent[0]
-    assert result == {}
+    assert result == {"objects": {}, "meta": {}}
 
 
 # === Clipping plane ===


### PR DESCRIPTION
## Summary
Combines and supersedes #20 and #21, incorporating Copilot review feedback.

### Grid API
- `show_grid(visible, size, divisions)` — toggle/resize ground grid (hidden by default)
- Proper geometry/material disposal on resize

### Animation cleanup
- `stop_animation()` resets draw ranges to 1.0 (bead meshes no longer stay partially drawn)
- `clear()` resets animation state via extracted `_resetAnimationState()` (includes `_baselineVisibility.clear()`)

### Async race protection
- Generation counters (`_sceneGeneration`, `_animGeneration`) guard all 4 async HTTP fetch handlers against stale completion after `clear_scene` or animation replacement
- Counters also increment on WebSocket reconnect
- `_stopAnimation()` now increments `_animGeneration` to discard in-flight `load_animation_http` fetches
- `load_animation_http` pre-increments `_animGeneration` so the most recent request wins when overlapping

### Stale refs cache fix
- All channel apply functions (`transforms`, `colors`, `visibility`, `draw_ranges`, `opacity`) now validate cached ref against current `_objects` map entry every frame, not just on cache miss — fixes stale references after `delete_object` or ID reuse
- `clip_times` mixer cache similarly validated against current `_mixers` map

### Pending fetches accounting
- Removed `_pendingFetches = 0` reset on reconnect — in-flight HTTP fetches from the previous connection still run their `finally { _onFetchEnd() }`, which would drive the counter negative

### Channel refs optimization
- `draw_ranges` and `clip_times` channel apply functions now use the `refs` cache, eliminating per-frame `Map.get()` lookups (fixes TS diagnostic about unused `refs` parameter)

### query_scene restructured
- **Breaking**: returns `{"objects": {...}, "meta": {...}}` instead of flat dict (addresses Copilot review: user object IDs could collide with metadata keys)
- Per-object `drawRange` with `Infinity`/`NaN` clamping (addresses Copilot review: `JSON.stringify(Infinity)` → `null`)
- `meta` includes `animation.playing`, `grid.visible`, `pending_fetches`

### WebSocket connect
- Removed HTTP fetch probe from `connect()` — eliminates 404 spam on FastAPI/non-HTTP WS routes and ~30s initial connection delay when viewer loads before server is ready
- Retries via existing `onclose` handler (500ms)

### add_mesh transform support
- Added `position`, `rotation`, `scale`, `matrix` parameters to `add_mesh()` (matching `add_model()` signature)

## Test plan
- [x] All 123 tests pass (120 unit + 3 new browser integration)
- [x] Linting clean
- [ ] Manual: `viewer.show_grid(True, 20, 20)` then `viewer.show_grid(False)`
- [ ] Manual: load animation with draw_ranges, stop, verify full mesh visible
- [ ] Manual: send `clear_scene` while large model loading, verify discarded
- [ ] Manual: verify no 404 on connect when served behind FastAPI
- [ ] Manual: `add_mesh(..., position=[1,0,0])` places mesh correctly
- [ ] Manual: delete + recreate object during animation, verify channel applies to new object

🤖 Generated with [Claude Code](https://claude.com/claude-code)