### PR TITLE
Add scene visibility, clear_animation, and unknown message warning

### DIFF
--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -786,6 +786,10 @@ class ViewerClient:
         """Set object visibility."""
         self._send({"type": "set_visibility", "id": id, "visible": visible})
 
+    def set_scene_visibility(self, visibility: dict[str, bool]):
+        """Set visibility for multiple objects atomically. Also updates animation baseline."""
+        self._send({"type": "set_scene_visibility", "visibility": visibility})
+
     def set_color(self, id: str, color: int, opacity: Optional[float] = None):
         """Set object material color, and optionally opacity (0.0-1.0)."""
         msg = {"type": "set_color", "id": id, "color": color}
@@ -1093,6 +1097,15 @@ class ViewerClient:
         """Stop animation playback, reset draw ranges, and return to real-time mode."""
         self._current_animation = None
         self._send({"type": "stop_animation"})
+
+    def clear_animation(self) -> None:
+        """Stop animation without restoring baseline visibility.
+
+        Unlike stop_animation(), visibility changes made via set_scene_visibility()
+        before this call are preserved.
+        """
+        self._current_animation = None
+        self._send({"type": "clear_animation"})
 
     def list_objects(self, timeout: float = 5.0) -> List[str]:
         """Get list of object IDs currently in the viewer."""

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -1101,8 +1101,8 @@ class ViewerClient:
     def clear_animation(self) -> None:
         """Stop animation without restoring baseline visibility.
 
-        Unlike stop_animation(), visibility changes made via set_scene_visibility()
-        before this call are preserved.
+        Unlike stop_animation(), this leaves the current visibility state as-is
+        instead of restoring baseline visibility.
         """
         self._current_animation = None
         self._send({"type": "clear_animation"})

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1452,8 +1452,10 @@ class ThreeJSViewer {
     _setSceneVisibility(visibility) {
         for (const [id, visible] of Object.entries(visibility)) {
             const obj = this._objects.get(id);
-            if (obj) obj.visible = visible;
-            this._baselineVisibility.set(id, visible);
+            if (obj) {
+                obj.visible = visible;
+                this._baselineVisibility.set(id, visible);
+            }
         }
     }
 

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2561,6 +2561,8 @@ class ThreeJSViewer {
                         this._assetsComplete = true;
                         this._maybeNotifyAssetsLoaded();
                         break;
+                    default:
+                        console.warn(`Unknown message type: '${data.type}'`);
                 }
             };
         };

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1449,6 +1449,14 @@ class ThreeJSViewer {
         if (obj) obj.visible = visible;
     }
 
+    _setSceneVisibility(visibility) {
+        for (const [id, visible] of Object.entries(visibility)) {
+            const obj = this._objects.get(id);
+            if (obj) obj.visible = visible;
+            this._baselineVisibility.set(id, visible);
+        }
+    }
+
     _clearScene() {
         this._sceneGeneration++;
         this._resetAnimationState();
@@ -1552,12 +1560,14 @@ class ThreeJSViewer {
         this._updateTrackingUI();
     }
 
-    _stopAnimation() {
+    _stopAnimation(restoreVisibility = true) {
         this._animGeneration++;
         this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
-        for (const [id, baselineVisible] of this._baselineVisibility) {
-            const obj = this._objects.get(id);
-            if (obj) obj.visible = baselineVisible;
+        if (restoreVisibility) {
+            for (const [id, baselineVisible] of this._baselineVisibility) {
+                const obj = this._objects.get(id);
+                if (obj) obj.visible = baselineVisible;
+            }
         }
         // Reset draw ranges to full
         for (const id of this._objects.keys()) {
@@ -2124,6 +2134,9 @@ class ThreeJSViewer {
                     case 'set_visibility':
                         this._setVisibility(data.id, data.visible);
                         break;
+                    case 'set_scene_visibility':
+                        this._setSceneVisibility(data.visibility);
+                        break;
                     case 'clear_scene':
                         this._clearScene();
                         break;
@@ -2461,6 +2474,9 @@ class ThreeJSViewer {
                     }
                     case 'stop_animation':
                         this._stopAnimation();
+                        break;
+                    case 'clear_animation':
+                        this._stopAnimation(false);
                         break;
                     case 'set_clip_time':
                         this._setClipTime(data.id, data.time);

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -989,8 +989,10 @@ export class ThreeJSViewer {
     _setSceneVisibility(visibility) {
         for (const [id, visible] of Object.entries(visibility)) {
             const obj = this._objects.get(id);
-            if (obj) obj.visible = visible;
-            this._baselineVisibility.set(id, visible);
+            if (obj) {
+                obj.visible = visible;
+                this._baselineVisibility.set(id, visible);
+            }
         }
     }
 

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -986,6 +986,14 @@ export class ThreeJSViewer {
         if (obj) obj.visible = visible;
     }
 
+    _setSceneVisibility(visibility) {
+        for (const [id, visible] of Object.entries(visibility)) {
+            const obj = this._objects.get(id);
+            if (obj) obj.visible = visible;
+            this._baselineVisibility.set(id, visible);
+        }
+    }
+
     _clearScene() {
         this._sceneGeneration++;
         this._resetAnimationState();
@@ -1089,12 +1097,14 @@ export class ThreeJSViewer {
         this._updateTrackingUI();
     }
 
-    _stopAnimation() {
+    _stopAnimation(restoreVisibility = true) {
         this._animGeneration++;
         this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
-        for (const [id, baselineVisible] of this._baselineVisibility) {
-            const obj = this._objects.get(id);
-            if (obj) obj.visible = baselineVisible;
+        if (restoreVisibility) {
+            for (const [id, baselineVisible] of this._baselineVisibility) {
+                const obj = this._objects.get(id);
+                if (obj) obj.visible = baselineVisible;
+            }
         }
         // Reset draw ranges to full
         for (const id of this._objects.keys()) {
@@ -1661,6 +1671,9 @@ export class ThreeJSViewer {
                     case 'set_visibility':
                         this._setVisibility(data.id, data.visible);
                         break;
+                    case 'set_scene_visibility':
+                        this._setSceneVisibility(data.visibility);
+                        break;
                     case 'clear_scene':
                         this._clearScene();
                         break;
@@ -1999,6 +2012,9 @@ export class ThreeJSViewer {
                     case 'stop_animation':
                         this._stopAnimation();
                         break;
+                    case 'clear_animation':
+                        this._stopAnimation(false);
+                        break;
                     case 'set_clip_time':
                         this._setClipTime(data.id, data.time);
                         break;
@@ -2082,6 +2098,8 @@ export class ThreeJSViewer {
                         this._assetsComplete = true;
                         this._maybeNotifyAssetsLoaded();
                         break;
+                    default:
+                        console.warn(`Unknown message type: '${data.type}'`);
                 }
             };
         };


### PR DESCRIPTION
## Summary
- **`set_scene_visibility`** — batch visibility updates that always persist to animation baseline, so visibility set before an animation loads is correctly preserved
- **`clear_animation`** — stops animation without restoring baseline visibility, reusing `_stopAnimation(restoreVisibility=false)` to avoid logic duplication
- **Unknown message warning** — `default` case in message switch logs unknown types to console instead of silently ignoring them

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] `uv run pytest` — 126 tests pass
- [ ] Manual: call `set_scene_visibility()` before loading an animation, verify visibility is preserved after `stop_animation()`
- [ ] Manual: call `clear_animation()`, verify visibility is NOT restored to baseline
- [ ] Manual: send an unknown message type, verify `console.warn` appears in browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)