### PR TITLE
Animation lifecycle cleanup: preserve state on swap, rename stop→unload, add pause/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Animation lifecycle
+
+- **`load_animation` preserves playback state on subsequent loads.** The first call to `load_animation` (when no animation is loaded) still starts at t=0 and force-plays, just like before. But a *subsequent* call (one already loaded) now preserves the current playhead time (clamped to the new duration), play state, and camera-tracking — only the underlying frame data is swapped. This makes the "swap mid-playback" pattern (reconcilers, tab switches between related animations) flicker-free without any caller bookkeeping. Pass `load_animation(anim, restart=True)` to force the old "snap to t=0 and force-play" behavior on a swap.
+- **`load_animation(autoplay=False)`** — load the animation paused on first-load (or on a restart) instead of starting playback immediately. No effect on a swap, where the prior play state is preserved.
+- **`pause_animation()` / `resume_animation()`** — new Python API for pause/resume from a script. Previously pause/resume was browser-only (spacebar / play button).
+- **Renamed `stop_animation()` / `clear_animation()` → `unload_animation(restore_visibility=True)`.** The old name implied "pause," but the method actually exits animation mode entirely (re-enables `matrixAutoUpdate`, resets draw ranges, optionally restores baseline visibility, hides controls). The rename makes the contract honest, and the two old methods collapse into one with a parameter (`restore_visibility=False` matches the old `clear_animation` semantic). **Breaking**: external callers of `stop_animation()` / `clear_animation()` must rename. No shim.
+
 ### Internal
 
 - Decompose `viewer.js` god-class into in-file controller classes (`ParametricTube`, `CameraController`, `ShadingDebugController`) plus shared ring/color helpers as free functions. Viewer now type-checked via JSDoc + `// @ts-check` (run `npx tsc --noEmit -p jsconfig.json`). No behavior change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,11 @@ A lightweight Three.js viewer designed to be controlled from Python/Jupyter note
 - **Streaming mode**: Real-time updates from Python (`batch_update()`, `set_matrix()`)
 - **Looping mode**: Pre-computed frames with interactive playback (`load_animation()`)
 
+### Animation lifecycle
+- **`load_animation(anim)`** — first call (no animation loaded yet) starts at t=0 and force-plays. Subsequent calls preserve the current playhead time (clamped to the new duration), play state, and camera-tracking — only the underlying frame data is swapped. Pass `restart=True` to force the first-load behavior on a swap. Pass `autoplay=False` to load paused on first-load (no effect on a swap, where prior play state is preserved).
+- **`pause_animation()` / `resume_animation()`** — pause/resume at the current playhead. No-op if no animation loaded.
+- **`unload_animation(restore_visibility=True)`** — exit animation mode entirely: re-enables `matrixAutoUpdate` on every object (animation pins it off), resets every draw range to 1.0, optionally restores baseline visibility, hides the controls UI. This is **not** a pause. Replaces the older `stop_animation()` / `clear_animation()` (use `restore_visibility=False` for the old `clear_animation` semantic).
+
 ### Supported Object Types
 - **Groups**: `add_group(id, parent=...)` — empty transform nodes for parent-child hierarchies. Children inherit parent transforms. All `add_*` methods accept an optional `parent` parameter.
 - Primitives: box, sphere, cylinder, capsule (with optional roughness/metalness)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -174,7 +174,9 @@ All messages are JSON (text) or binary with JSON header.
 
 ```json
 {"type": "load_animation", "animation": {"duration": 10, "frames": [...], "markers": [...]}}
-{"type": "stop_animation"}
+{"type": "unload_animation", "restore_visibility": true}
+{"type": "pause_animation"}
+{"type": "resume_animation"}
 ```
 
 For binary-channel animations, the message is `load_animation_http` with a channel manifest:

--- a/examples/01_primitives.py
+++ b/examples/01_primitives.py
@@ -13,7 +13,7 @@ import math
 # Connect to viewer (starts WebSocket server, waits for browser)
 v = viewer()
 v.clear()
-v.stop_animation()
+v.unload_animation()
 
 # Add a ground plane (flat box)
 v.add_box(

--- a/examples/02_polylines.py
+++ b/examples/02_polylines.py
@@ -13,7 +13,7 @@ from threejs_viewer import viewer
 
 v = viewer()
 v.clear()
-v.stop_animation()
+v.unload_animation()
 
 # Add a subtle ground reference
 v.add_box(

--- a/examples/06_realtime_streaming.py
+++ b/examples/06_realtime_streaming.py
@@ -16,7 +16,7 @@ from threejs_viewer import viewer
 
 v = viewer()
 v.clear()
-v.stop_animation()  # Clear any previous animation UI
+v.unload_animation()  # Clear any previous animation UI
 
 # Ground
 v.add_box(

--- a/examples/07_stress_test.py
+++ b/examples/07_stress_test.py
@@ -95,7 +95,7 @@ print(f"Generated in {time.time() - start:.2f}s ({points.nbytes / 1024 / 1024:.1
 # Connect and send
 v = viewer()
 v.clear()
-v.stop_animation()
+v.unload_animation()
 
 print("Sending polyline to viewer...")
 start = time.time()

--- a/examples/14_grouping.py
+++ b/examples/14_grouping.py
@@ -28,7 +28,7 @@ def mat_ry(tx, ty, tz, angle):
 
 v = viewer()
 v.clear()
-v.stop_animation()
+v.unload_animation()
 
 # Ground plane
 v.add_box(

--- a/examples/16_clipping_plane.py
+++ b/examples/16_clipping_plane.py
@@ -21,7 +21,7 @@ from threejs_viewer import Toolpath, viewer
 
 v = viewer()
 v.clear()
-v.stop_animation()
+v.unload_animation()
 
 # Build a dense scene to clip through
 

--- a/plans/viewer-refactor-pass-two.md
+++ b/plans/viewer-refactor-pass-two.md
@@ -68,7 +68,7 @@ Project is early; backward-compat on internal JS field names is not a goal. Two 
 | `v._getFrameAtTime(t)` | `v._anim.getFrameAtTime(t)` |
 | `v._applyFrame(i, t)` | `v._anim.applyFrame(i, t)` |
 
-The WS-message API (`set_clipping_plane` / `set_clipping_slab` / `disable_clipping_plane` / `set_clipping_defaults` / `load_animation` / `stop_animation`) is external and MUST keep working — that's a dispatcher concern (`_onMessage` still routes those names to the right controller methods), not a field-name concern.
+The WS-message API (`set_clipping_plane` / `set_clipping_slab` / `disable_clipping_plane` / `set_clipping_defaults` / `load_animation` / `unload_animation`) is external and MUST keep working — that's a dispatcher concern (`_onMessage` still routes those names to the right controller methods), not a field-name concern.
 
 Also remove any compat getters left over from pass one (e.g., `_wireframeMode`) — grep confirms they're not used by tests.
 

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -1170,7 +1170,9 @@ class ViewerClient:
 
     # === Animation ===
 
-    def load_animation(self, animation) -> None:
+    def load_animation(
+        self, animation, *, restart: bool = False, autoplay: bool = True
+    ) -> None:
         """
         Load an animation for playback in the viewer.
 
@@ -1178,8 +1180,22 @@ class ViewerClient:
         colors, visibility, etc.) with JSON for sparse per-frame metadata
         (clip_times, or any channel without a binary version).
 
+        First load (no animation currently loaded) starts playback at t=0
+        with camera-tracking installed from the new animation's metadata.
+        Subsequent loads (an animation is already loaded) preserve the
+        current playhead time (clamped to the new duration), play state,
+        and camera-tracking — only the underlying frame data is swapped.
+        Pass ``restart=True`` to force the first-load behavior on a swap.
+
         Args:
             animation: Animation object with pre-computed frames
+            restart: If True, reset to t=0, force-play, and re-install
+                camera-tracking from the animation's metadata, even when
+                an animation is already loaded.
+            autoplay: If False, load paused on first-load (or on a
+                restart) instead of starting playback immediately. Has
+                no effect on a swap (the prior play state is preserved
+                regardless).
 
         Example:
             frames = []
@@ -1353,21 +1369,50 @@ class ViewerClient:
             header["camera_follow"] = animation.camera_follow
         if animation.camera_lookat is not None:
             header["camera_lookat"] = animation.camera_lookat
+        if restart:
+            header["restart"] = True
+        if not autoplay:
+            header["autoplay"] = False
         self._send(header)
 
-    def stop_animation(self) -> None:
-        """Stop animation playback, reset draw ranges, and return to real-time mode."""
-        self._current_animation = None
-        self._send({"type": "stop_animation"})
+    def unload_animation(self, *, restore_visibility: bool = True) -> None:
+        """Exit animation mode and return to real-time control.
 
-    def clear_animation(self) -> None:
-        """Stop animation without restoring baseline visibility.
+        Re-enables matrixAutoUpdate on every object (animation pins it off
+        so its 4x4 channel writes aren't clobbered), resets every draw
+        range to 1.0, optionally restores the visibility state captured
+        when the animation was loaded, and hides the animation controls.
 
-        Unlike stop_animation(), this leaves the current visibility state as-is
-        instead of restoring baseline visibility.
+        This is not a pause — for that, use ``pause_animation()``.
+
+        Args:
+            restore_visibility: If True (default), restore each object's
+                visibility to the value it had when the animation was
+                loaded. If False, leave current visibility as-is (useful
+                when the animation's final visibility state is what you
+                want to keep).
         """
         self._current_animation = None
-        self._send({"type": "clear_animation"})
+        self._send(
+            {
+                "type": "unload_animation",
+                "restore_visibility": restore_visibility,
+            }
+        )
+
+    def pause_animation(self) -> None:
+        """Pause animation playback at the current playhead position.
+
+        No-op if no animation is loaded. Resume with ``resume_animation()``.
+        """
+        self._send({"type": "pause_animation"})
+
+    def resume_animation(self) -> None:
+        """Resume paused animation playback from the current playhead position.
+
+        No-op if no animation is loaded.
+        """
+        self._send({"type": "resume_animation"})
 
     def list_objects(self, timeout: float = 5.0) -> List[str]:
         """Get list of object IDs currently in the viewer."""

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -3985,7 +3985,20 @@ class ThreeJSViewer {
 
     // ========== Animation ==========
 
-    _loadAnimation(animData) {
+    _loadAnimation(animData, opts = {}) {
+        // First load (no animation yet) or explicit restart resets playback to t=0,
+        // installs camera-tracking from the new metadata, and force-plays. A
+        // subsequent load (animation already loaded, restart not set) preserves
+        // playhead time, play state, and camera-tracking — only the underlying
+        // frame data is swapped. See plans/soft-snacking-deer.md for rationale.
+        const isSwap = this._animation != null && !opts.restart;
+        const prevTime = this._animationTime;
+        const prevPlaying = this._animationPlaying;
+        const prevTrackMode = this._trackMode;
+        const prevTrackTargetId = this._trackTargetId;
+        const prevTrackInteractive = this._trackInteractive;
+        const prevTrackHasLastPos = this._trackHasLastPos;
+
         this._animGeneration++;
         this._animation = animData;
         this._animationTime = 0;
@@ -4041,29 +4054,41 @@ class ThreeJSViewer {
             }
         }
 
-        this._applyFrame(0);
-
-        // Camera tracking from animation metadata
-        this._trackHasLastPos = false;
-        this._trackInteractive = false;
-        if (animData.camera_follow) {
-            this._trackTargetId = animData.camera_follow;
-            this._trackMode = 'follow';
-        } else if (animData.camera_lookat) {
-            this._trackTargetId = animData.camera_lookat;
-            this._trackMode = 'lookat';
-        } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
-            this._trackMode = 'scripted';
-            this._trackTargetId = null;
+        if (isSwap) {
+            // Preserve playback continuity across the swap.
+            this._animationTime = animData.duration > 0 ? Math.min(prevTime, animData.duration) : 0;
+            this._animationPlaying = prevPlaying;
+            this._trackMode = prevTrackMode;
+            this._trackTargetId = prevTrackTargetId;
+            this._trackInteractive = prevTrackInteractive;
+            this._trackHasLastPos = prevTrackHasLastPos;
+            this._updateTrackingUI();
+            this._seekToTime(this._animationTime);
         } else {
-            this._trackMode = 'off';
-            this._trackTargetId = null;
-        }
-        this._updateTrackingUI();
+            this._applyFrame(0);
 
-        this._animationPlaying = true;
+            // Camera tracking from animation metadata
+            this._trackHasLastPos = false;
+            this._trackInteractive = false;
+            if (animData.camera_follow) {
+                this._trackTargetId = animData.camera_follow;
+                this._trackMode = 'follow';
+            } else if (animData.camera_lookat) {
+                this._trackTargetId = animData.camera_lookat;
+                this._trackMode = 'lookat';
+            } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
+                this._trackMode = 'scripted';
+                this._trackTargetId = null;
+            } else {
+                this._trackMode = 'off';
+                this._trackTargetId = null;
+            }
+            this._updateTrackingUI();
+
+            this._animationPlaying = opts.autoplay !== false;
+        }
         this._lastAnimationUpdate = performance.now();
-        console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
+        console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s${isSwap ? ' (swap)' : ''}`);
     }
 
     _resetAnimationState() {
@@ -4078,7 +4103,7 @@ class ThreeJSViewer {
         this._updateTrackingUI();
     }
 
-    _stopAnimation(restoreVisibility = true) {
+    _unloadAnimation(restoreVisibility = true) {
         this._animGeneration++;
         this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
         if (restoreVisibility) {
@@ -4840,7 +4865,10 @@ class ThreeJSViewer {
                         break;
                     }
                     case 'load_animation':
-                        this._loadAnimation(data.animation);
+                        this._loadAnimation(data.animation, {
+                            restart: !!data.restart,
+                            autoplay: data.autoplay !== false,
+                        });
                         break;
                     case 'load_animation_http': {
                         this._onFetchStart();
@@ -4928,6 +4956,9 @@ class ThreeJSViewer {
                                     channels: channels,
                                     camera_follow: data.camera_follow || null,
                                     camera_lookat: data.camera_lookat || null,
+                                }, {
+                                    restart: !!data.restart,
+                                    autoplay: data.autoplay !== false,
                                 });
                                 console.log(`  total: ${(performance.now() - t0).toFixed(0)}ms`);
                             } catch (e) {
@@ -5452,11 +5483,21 @@ class ThreeJSViewer {
                         }
                         break;
                     }
-                    case 'stop_animation':
-                        this._stopAnimation();
+                    case 'unload_animation':
+                        this._unloadAnimation(data.restore_visibility !== false);
                         break;
-                    case 'clear_animation':
-                        this._stopAnimation(false);
+                    case 'pause_animation':
+                        if (this._animation) {
+                            this._animationPlaying = false;
+                            this._updateAnimationUI();
+                        }
+                        break;
+                    case 'resume_animation':
+                        if (this._animation) {
+                            this._animationPlaying = true;
+                            this._lastAnimationUpdate = performance.now();
+                            this._updateAnimationUI();
+                        }
                         break;
                     case 'set_clip_time':
                         this._setClipTime(data.id, data.time);

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -3107,7 +3107,20 @@ export class ThreeJSViewer {
 
     // ========== Animation ==========
 
-    _loadAnimation(animData) {
+    _loadAnimation(animData, opts = {}) {
+        // First load (no animation yet) or explicit restart resets playback to t=0,
+        // installs camera-tracking from the new metadata, and force-plays. A
+        // subsequent load (animation already loaded, restart not set) preserves
+        // playhead time, play state, and camera-tracking — only the underlying
+        // frame data is swapped. See plans/soft-snacking-deer.md for rationale.
+        const isSwap = this._animation != null && !opts.restart;
+        const prevTime = this._animationTime;
+        const prevPlaying = this._animationPlaying;
+        const prevTrackMode = this._trackMode;
+        const prevTrackTargetId = this._trackTargetId;
+        const prevTrackInteractive = this._trackInteractive;
+        const prevTrackHasLastPos = this._trackHasLastPos;
+
         this._animGeneration++;
         this._animation = animData;
         this._animationTime = 0;
@@ -3163,29 +3176,41 @@ export class ThreeJSViewer {
             }
         }
 
-        this._applyFrame(0);
-
-        // Camera tracking from animation metadata
-        this._trackHasLastPos = false;
-        this._trackInteractive = false;
-        if (animData.camera_follow) {
-            this._trackTargetId = animData.camera_follow;
-            this._trackMode = 'follow';
-        } else if (animData.camera_lookat) {
-            this._trackTargetId = animData.camera_lookat;
-            this._trackMode = 'lookat';
-        } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
-            this._trackMode = 'scripted';
-            this._trackTargetId = null;
+        if (isSwap) {
+            // Preserve playback continuity across the swap.
+            this._animationTime = animData.duration > 0 ? Math.min(prevTime, animData.duration) : 0;
+            this._animationPlaying = prevPlaying;
+            this._trackMode = prevTrackMode;
+            this._trackTargetId = prevTrackTargetId;
+            this._trackInteractive = prevTrackInteractive;
+            this._trackHasLastPos = prevTrackHasLastPos;
+            this._updateTrackingUI();
+            this._seekToTime(this._animationTime);
         } else {
-            this._trackMode = 'off';
-            this._trackTargetId = null;
-        }
-        this._updateTrackingUI();
+            this._applyFrame(0);
 
-        this._animationPlaying = true;
+            // Camera tracking from animation metadata
+            this._trackHasLastPos = false;
+            this._trackInteractive = false;
+            if (animData.camera_follow) {
+                this._trackTargetId = animData.camera_follow;
+                this._trackMode = 'follow';
+            } else if (animData.camera_lookat) {
+                this._trackTargetId = animData.camera_lookat;
+                this._trackMode = 'lookat';
+            } else if (animData.channels?.camera_target || animData.channels?.camera_position) {
+                this._trackMode = 'scripted';
+                this._trackTargetId = null;
+            } else {
+                this._trackMode = 'off';
+                this._trackTargetId = null;
+            }
+            this._updateTrackingUI();
+
+            this._animationPlaying = opts.autoplay !== false;
+        }
         this._lastAnimationUpdate = performance.now();
-        console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s`);
+        console.log(`Animation loaded: ${this._animation.frames.length} frames, ${this._animation.duration.toFixed(2)}s${isSwap ? ' (swap)' : ''}`);
     }
 
     _resetAnimationState() {
@@ -3200,7 +3225,7 @@ export class ThreeJSViewer {
         this._updateTrackingUI();
     }
 
-    _stopAnimation(restoreVisibility = true) {
+    _unloadAnimation(restoreVisibility = true) {
         this._animGeneration++;
         this._objects.forEach((obj) => { obj.matrixAutoUpdate = true; });
         if (restoreVisibility) {
@@ -3962,7 +3987,10 @@ export class ThreeJSViewer {
                         break;
                     }
                     case 'load_animation':
-                        this._loadAnimation(data.animation);
+                        this._loadAnimation(data.animation, {
+                            restart: !!data.restart,
+                            autoplay: data.autoplay !== false,
+                        });
                         break;
                     case 'load_animation_http': {
                         this._onFetchStart();
@@ -4050,6 +4078,9 @@ export class ThreeJSViewer {
                                     channels: channels,
                                     camera_follow: data.camera_follow || null,
                                     camera_lookat: data.camera_lookat || null,
+                                }, {
+                                    restart: !!data.restart,
+                                    autoplay: data.autoplay !== false,
                                 });
                                 console.log(`  total: ${(performance.now() - t0).toFixed(0)}ms`);
                             } catch (e) {
@@ -4574,11 +4605,21 @@ export class ThreeJSViewer {
                         }
                         break;
                     }
-                    case 'stop_animation':
-                        this._stopAnimation();
+                    case 'unload_animation':
+                        this._unloadAnimation(data.restore_visibility !== false);
                         break;
-                    case 'clear_animation':
-                        this._stopAnimation(false);
+                    case 'pause_animation':
+                        if (this._animation) {
+                            this._animationPlaying = false;
+                            this._updateAnimationUI();
+                        }
+                        break;
+                    case 'resume_animation':
+                        if (this._animation) {
+                            this._animationPlaying = true;
+                            this._lastAnimationUpdate = performance.now();
+                            this._updateAnimationUI();
+                        }
                         break;
                     case 'set_clip_time':
                         this._setClipTime(data.id, data.time);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -72,8 +72,8 @@ def test_clear_scene(viewer_client, viewer_page):
 
 
 @pytest.mark.browser
-def test_stop_animation_resets_draw_range(viewer_client, viewer_page):
-    """stop_animation() resets draw ranges to full."""
+def test_unload_animation_resets_draw_range(viewer_client, viewer_page):
+    """unload_animation() resets draw ranges to full."""
     # Use a real mesh so draw_range metadata (userData.isMesh, totalIndexCount) is set
     positions = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
     indices = np.array([0, 1, 2], dtype=np.uint32)
@@ -94,7 +94,7 @@ def test_stop_animation_resets_draw_range(viewer_client, viewer_page):
         if result["meta"]["animation"]["playing"]:
             break
     assert result["meta"]["animation"]["playing"] is True, "Animation did not start"
-    viewer_client.stop_animation()
+    viewer_client.unload_animation()
     time.sleep(0.1)
     result = viewer_client.query_scene()
     assert result["objects"]["m1"]["drawRange"] == 1.0


### PR DESCRIPTION
## Summary

Three related changes to the animation API, driven by the same root issue: today's defaults assume "every load is a fresh start, every stop is a teardown," which doesn't match how callers actually use the viewer.

- **`load_animation` preserves playback state on subsequent loads.** First call (no animation loaded) still starts at t=0 and force-plays. A *subsequent* call now preserves the current playhead time (clamped to the new duration), play state, and camera-tracking — only the underlying frame data is swapped. Makes the "swap mid-playback" pattern (reconcilers, tab switches between related animations) flicker-free with no caller bookkeeping.
  - `load_animation(anim, restart=True)` — opt out, force the old "snap to t=0 + force-play" on a swap.
  - `load_animation(anim, autoplay=False)` — opt out of auto-play on first-load (load paused).
- **Renamed `stop_animation()` / `clear_animation()` → `unload_animation(restore_visibility=True)`.** The old name implied "pause" but the method exits animation mode entirely (re-enables `matrixAutoUpdate`, resets draw ranges, optionally restores baseline visibility, hides controls). Two methods collapse into one with a parameter. **Breaking — no shim.** All in-tree callers migrated atomically.
- **Added `pause_animation()` / `resume_animation()`** — Python-side pause/resume; previously browser-only (spacebar / play button).

Motivated by an observed downstream issue in ribweaver's panel UI: swapping between the Toolpath and Simulate tabs — which carry different animation blobs but the same logical timeline — used to snap the playhead to 0 and either freeze (paused) or visibly flash (playing).

## Test plan

- [x] \`uv run python src/threejs_viewer/viewer/build.py\` — viewer.html regenerated
- [x] \`npx tsc --noEmit -p jsconfig.json\` — type-check clean
- [x] \`uv run ruff check . && uv run ruff format --check .\` — clean
- [x] \`uv run pytest\` — 154/154 pass (includes browser tests)
- [ ] Manual REPL walkthrough:
  - Load animation A, wait ~2 s. \`load_animation(B)\` with \`B.duration ≈ A.duration\` → playhead stays put, no flash.
  - \`pause_animation()\` / \`resume_animation()\` round-trip works.
  - Pause, then \`load_animation(C)\` → C remains paused at preserved time.
  - \`load_animation(D)\` with \`D.duration < prevTime\` → clamps to \`D.duration\`.
  - \`load_animation(E, restart=True)\` → snaps to 0, force-plays (today's behavior).
  - \`load_animation(F, autoplay=False)\` on a fresh viewer → loads paused at t=0.
  - \`unload_animation()\` then \`load_animation(G)\` → fresh first-load.
  - \`unload_animation(restore_visibility=False)\` → matches old \`clear_animation\` semantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)