### PR TITLE
Fix camera-tracking drift on animation swap + release v0.0.21

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -3999,7 +3999,6 @@ class ThreeJSViewer {
         const prevTrackMode = this._trackMode;
         const prevTrackTargetId = this._trackTargetId;
         const prevTrackInteractive = this._trackInteractive;
-        const prevTrackHasLastPos = this._trackHasLastPos;
 
         this._animGeneration++;
         this._animation = animData;
@@ -4063,7 +4062,10 @@ class ThreeJSViewer {
             this._trackMode = prevTrackMode;
             this._trackTargetId = prevTrackTargetId;
             this._trackInteractive = prevTrackInteractive;
-            this._trackHasLastPos = prevTrackHasLastPos;
+            // Trajectory is replaced — treat the next tracking tick as a first
+            // frame (snap orbit target, keep camera offset) rather than
+            // computing a delta against the old bead's last position.
+            this._trackHasLastPos = false;
             this._updateTrackingUI();
             this._seekToTime(this._animationTime);
         } else {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -3121,7 +3121,6 @@ export class ThreeJSViewer {
         const prevTrackMode = this._trackMode;
         const prevTrackTargetId = this._trackTargetId;
         const prevTrackInteractive = this._trackInteractive;
-        const prevTrackHasLastPos = this._trackHasLastPos;
 
         this._animGeneration++;
         this._animation = animData;
@@ -3185,7 +3184,10 @@ export class ThreeJSViewer {
             this._trackMode = prevTrackMode;
             this._trackTargetId = prevTrackTargetId;
             this._trackInteractive = prevTrackInteractive;
-            this._trackHasLastPos = prevTrackHasLastPos;
+            // Trajectory is replaced — treat the next tracking tick as a first
+            // frame (snap orbit target, keep camera offset) rather than
+            // computing a delta against the old bead's last position.
+            this._trackHasLastPos = false;
             this._updateTrackingUI();
             this._seekToTime(this._animationTime);
         } else {


### PR DESCRIPTION
## Summary
- On a `load_animation` swap, `_trackLastPos` still points at the old trajectory's last position, so the next `_updateCameraTracking` tick computes a spurious delta and the orbit camera slides. Repeated small swaps (e.g. ribweaver nudging a spline-smoothness slider) accumulate into visible framing drift.
- Fix: drop `_trackHasLastPos` across the swap so the next tick takes the first-frame branch (snap orbit target, keep camera offset) — the correct behavior when the underlying trajectory is replaced.
- Continuous fields that should survive a swap (playhead, play state, track mode, target id, interactive override) are still preserved.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest` (158 passed)
- [x] `npx tsc --noEmit -p jsconfig.json` (clean)
- [ ] Manual: in ribweaver, build a toolpath, animate, nudge `Smoothness*` repeatedly by 0.1 — camera framing should stay put across all increments; playhead still preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)