### PR TITLE
Document embedding API and HTTP probe contract

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,18 +168,24 @@ The standalone `viewer.html` is the same code with `htmlTemplate` and `cubemapDa
 inlined by `viewer/build.py` — embedders supply those themselves.
 
 **WS host contract (the probe).** Before opening each WebSocket, `connect()`
-issues a `mode: 'no-cors'` HTTP GET to the same host:port as `wsUrl`. The
-browser logs `WebSocket connection to '...' failed` whenever a `new WebSocket()`
-fails to upgrade and there's no API to silence it, so the probe is what keeps
-devtools quiet while the Python server is down or restarting. Any HTTP response
-counts as "server is up" — including 426 Upgrade Required, which is what a
-WebSocket endpoint normally returns to a plain GET. Only a TCP-level failure
+issues a `mode: 'no-cors'` HTTP GET to the URL derived from `wsUrl` by swapping
+only the scheme (`ws:` → `http:`, `wss:` → `https:`). Path and query are
+preserved, so the probe targets the same host, port, **path, and query** as the
+pending WebSocket — not just the same host:port. An embedder using
+`ws://host:port/my-path` must answer plain HTTP on `http://host:port/my-path`,
+not just on `/`. The browser logs `WebSocket connection to '...' failed`
+whenever a `new WebSocket()` fails to upgrade and there's no API to silence it,
+so the probe is what keeps devtools quiet while the Python server is down or
+restarting. In `no-cors` mode, *any* HTTP response counts as "server is up" —
+different servers and proxies may return 200, 400, 404, or 426 for a plain GET
+to a WebSocket URL, and all of them satisfy the probe. Only a TCP-level failure
 aborts the attempt and schedules a retry.
 
 The standard Python `websockets` library satisfies this for free as part of the
 upgrade handshake. **If you point `wsUrl` at a different WS host (custom server,
-reverse proxy, etc.), that host must answer *something* on plain HTTP GET to the
-same port — otherwise the probe fails forever and the WebSocket is never tried.**
+reverse proxy, etc.), that host must answer *something* on plain HTTP GET for
+that same URL (same host, port, path, and query) — otherwise the probe fails
+forever and the WebSocket is never tried.**
 
 **HTTP sidecar.** Independent of the probe, `client.py` runs an HTTP blob server
 on `port + 1` (default 5667) for binary transfers (meshes, polylines, animation

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,6 +148,46 @@ The HTML viewer provides:
 - Keyboard shortcuts for frame stepping
 - Automatic reconnection to Python
 
+### Embedding the Viewer
+
+`viewer.js` exports `ThreeJSViewer` as an ES module so the viewer can be mounted
+into any host page (a docs site, a custom panel, an Electron shell):
+
+```js
+import { ThreeJSViewer } from './viewer.js';
+
+const viewer = new ThreeJSViewer(document.getElementById('viewer-root'), {
+    wsUrl: 'ws://localhost:5666',     // or wsPort: 5666
+    htmlTemplate: TEMPLATE_HTML,       // contents of viewer/template.html (required)
+    cubemapData: { px, nx, py, ny, pz, nz }, // optional: base64 JPEGs for PBR env
+    autoConnect: true,                 // default; pass false to call viewer.connect() yourself
+});
+```
+
+The standalone `viewer.html` is the same code with `htmlTemplate` and `cubemapData`
+inlined by `viewer/build.py` — embedders supply those themselves.
+
+**WS host contract (the probe).** Before opening each WebSocket, `connect()`
+issues a `mode: 'no-cors'` HTTP GET to the same host:port as `wsUrl`. The
+browser logs `WebSocket connection to '...' failed` whenever a `new WebSocket()`
+fails to upgrade and there's no API to silence it, so the probe is what keeps
+devtools quiet while the Python server is down or restarting. Any HTTP response
+counts as "server is up" — including 426 Upgrade Required, which is what a
+WebSocket endpoint normally returns to a plain GET. Only a TCP-level failure
+aborts the attempt and schedules a retry.
+
+The standard Python `websockets` library satisfies this for free as part of the
+upgrade handshake. **If you point `wsUrl` at a different WS host (custom server,
+reverse proxy, etc.), that host must answer *something* on plain HTTP GET to the
+same port — otherwise the probe fails forever and the WebSocket is never tried.**
+
+**HTTP sidecar.** Independent of the probe, `client.py` runs an HTTP blob server
+on `port + 1` (default 5667) for binary transfers (meshes, polylines, animation
+channels). The `blob_url` in each large-data message points to this port; the
+browser fetches with native `fetch()`. Embedders that proxy the WebSocket must
+also expose this sidecar (or rewrite `blob_url` to a reachable host) for binary
+loads to work.
+
 ## Message Protocol
 
 All messages are JSON (text) or binary with JSON header.

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2988,6 +2988,16 @@ class ThreeJSViewer {
      * @param {boolean} [options.autoConnect=true] - Whether to connect WebSocket immediately
      * @param {string}  [options.htmlTemplate] - HTML template string for UI controls
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
+     *
+     * Embedding contract: before opening each WebSocket, `connect()` issues a
+     * `mode: 'no-cors'` HTTP GET to the same host:port as `wsUrl` to suppress
+     * the browser's "WebSocket connection failed" console warning while the
+     * server is down. Any HTTP response (including 426 Upgrade Required)
+     * counts as "server is up" — only a TCP-level failure aborts the attempt.
+     * The standard `websockets` Python library satisfies this for free as part
+     * of the WS upgrade handshake. If your WS host sits behind a proxy that
+     * drops non-upgrade HTTP, make it answer *something* on plain GET, or the
+     * browser will never attempt the WebSocket.
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -4720,7 +4730,15 @@ class ThreeJSViewer {
         const doConnect = async () => {
             if (this._destroyed) return;
 
-            // Probe first to avoid browser console warnings on failed WS attempts
+            // Probe HTTP on the WS host:port before opening the WebSocket: a
+            // failed `new WebSocket()` always logs `WebSocket connection to
+            // '...' failed` to devtools and there's no way to silence it, so
+            // we only attempt the upgrade once we know something is listening.
+            // `mode: 'no-cors'` makes any HTTP response (200/404/426/...) count
+            // as success — only a TCP-level failure throws and triggers retry.
+            // The Python `websockets` server answers plain HTTP for free as part
+            // of the upgrade handshake; embedders pointing at a different WS host
+            // must ensure that host (or its proxy) returns *something* on GET.
             try {
                 await fetch(probeUrl, { mode: 'no-cors', signal: AbortSignal.timeout(400) });
             } catch {

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -2990,14 +2990,18 @@ class ThreeJSViewer {
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
      *
      * Embedding contract: before opening each WebSocket, `connect()` issues a
-     * `mode: 'no-cors'` HTTP GET to the same host:port as `wsUrl` to suppress
-     * the browser's "WebSocket connection failed" console warning while the
-     * server is down. Any HTTP response (including 426 Upgrade Required)
-     * counts as "server is up" — only a TCP-level failure aborts the attempt.
-     * The standard `websockets` Python library satisfies this for free as part
-     * of the WS upgrade handshake. If your WS host sits behind a proxy that
-     * drops non-upgrade HTTP, make it answer *something* on plain GET, or the
-     * browser will never attempt the WebSocket.
+     * `mode: 'no-cors'` HTTP GET to the URL derived from `wsUrl` by swapping
+     * the scheme (`ws:` → `http:`, `wss:` → `https:`). Path and query are
+     * preserved, so the probe targets the *full* `wsUrl` with only the scheme
+     * changed — an embedder using `ws://host:port/my-path` must answer plain
+     * HTTP on `http://host:port/my-path`, not just on `/`. In `no-cors` mode,
+     * any HTTP response counts as "server is up" (different servers/proxies
+     * may return 200, 400, 404, or 426 for a plain GET to a WS URL — all fine);
+     * only a TCP-level failure aborts the attempt. The standard `websockets`
+     * Python library satisfies this for free as part of the WS upgrade
+     * handshake. If your WS host sits behind a proxy that drops non-upgrade
+     * HTTP on that path, make it answer *something*, or the browser will
+     * never attempt the WebSocket.
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -4724,21 +4728,26 @@ class ThreeJSViewer {
     // ========== WebSocket ==========
 
     connect() {
-        // Derive HTTP probe URL from WS URL (same host/port)
+        // Derive the probe URL from the WS URL by swapping only the scheme
+        // (ws→http / wss→https). Path and query are preserved, so the probe
+        // targets the same endpoint as the eventual WebSocket upgrade.
         const probeUrl = this._wsUrl.replace(/^ws/, 'http');
 
         const doConnect = async () => {
             if (this._destroyed) return;
 
-            // Probe HTTP on the WS host:port before opening the WebSocket: a
-            // failed `new WebSocket()` always logs `WebSocket connection to
-            // '...' failed` to devtools and there's no way to silence it, so
-            // we only attempt the upgrade once we know something is listening.
-            // `mode: 'no-cors'` makes any HTTP response (200/404/426/...) count
-            // as success — only a TCP-level failure throws and triggers retry.
-            // The Python `websockets` server answers plain HTTP for free as part
-            // of the upgrade handshake; embedders pointing at a different WS host
-            // must ensure that host (or its proxy) returns *something* on GET.
+            // Probe HTTP on the same URL (minus scheme) as the pending
+            // WebSocket: a failed `new WebSocket()` always logs `WebSocket
+            // connection to '...' failed` to devtools and there's no way to
+            // silence it, so we only attempt the upgrade once we know
+            // something is listening. `mode: 'no-cors'` makes *any* HTTP
+            // response count as success (200/400/404/426/... — the exact
+            // status varies by server/proxy, all of them satisfy the probe);
+            // only a TCP-level failure throws and triggers retry. The Python
+            // `websockets` server answers plain HTTP for free as part of the
+            // upgrade handshake; embedders pointing at a different WS host
+            // must ensure that host (or its proxy) returns *something* on GET
+            // for the same path/query as `wsUrl`, not just for `/`.
             try {
                 await fetch(probeUrl, { mode: 'no-cors', signal: AbortSignal.timeout(400) });
             } catch {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -2110,6 +2110,16 @@ export class ThreeJSViewer {
      * @param {boolean} [options.autoConnect=true] - Whether to connect WebSocket immediately
      * @param {string}  [options.htmlTemplate] - HTML template string for UI controls
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
+     *
+     * Embedding contract: before opening each WebSocket, `connect()` issues a
+     * `mode: 'no-cors'` HTTP GET to the same host:port as `wsUrl` to suppress
+     * the browser's "WebSocket connection failed" console warning while the
+     * server is down. Any HTTP response (including 426 Upgrade Required)
+     * counts as "server is up" — only a TCP-level failure aborts the attempt.
+     * The standard `websockets` Python library satisfies this for free as part
+     * of the WS upgrade handshake. If your WS host sits behind a proxy that
+     * drops non-upgrade HTTP, make it answer *something* on plain GET, or the
+     * browser will never attempt the WebSocket.
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -3842,7 +3852,15 @@ export class ThreeJSViewer {
         const doConnect = async () => {
             if (this._destroyed) return;
 
-            // Probe first to avoid browser console warnings on failed WS attempts
+            // Probe HTTP on the WS host:port before opening the WebSocket: a
+            // failed `new WebSocket()` always logs `WebSocket connection to
+            // '...' failed` to devtools and there's no way to silence it, so
+            // we only attempt the upgrade once we know something is listening.
+            // `mode: 'no-cors'` makes any HTTP response (200/404/426/...) count
+            // as success — only a TCP-level failure throws and triggers retry.
+            // The Python `websockets` server answers plain HTTP for free as part
+            // of the upgrade handshake; embedders pointing at a different WS host
+            // must ensure that host (or its proxy) returns *something* on GET.
             try {
                 await fetch(probeUrl, { mode: 'no-cors', signal: AbortSignal.timeout(400) });
             } catch {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -2112,14 +2112,18 @@ export class ThreeJSViewer {
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
      *
      * Embedding contract: before opening each WebSocket, `connect()` issues a
-     * `mode: 'no-cors'` HTTP GET to the same host:port as `wsUrl` to suppress
-     * the browser's "WebSocket connection failed" console warning while the
-     * server is down. Any HTTP response (including 426 Upgrade Required)
-     * counts as "server is up" — only a TCP-level failure aborts the attempt.
-     * The standard `websockets` Python library satisfies this for free as part
-     * of the WS upgrade handshake. If your WS host sits behind a proxy that
-     * drops non-upgrade HTTP, make it answer *something* on plain GET, or the
-     * browser will never attempt the WebSocket.
+     * `mode: 'no-cors'` HTTP GET to the URL derived from `wsUrl` by swapping
+     * the scheme (`ws:` → `http:`, `wss:` → `https:`). Path and query are
+     * preserved, so the probe targets the *full* `wsUrl` with only the scheme
+     * changed — an embedder using `ws://host:port/my-path` must answer plain
+     * HTTP on `http://host:port/my-path`, not just on `/`. In `no-cors` mode,
+     * any HTTP response counts as "server is up" (different servers/proxies
+     * may return 200, 400, 404, or 426 for a plain GET to a WS URL — all fine);
+     * only a TCP-level failure aborts the attempt. The standard `websockets`
+     * Python library satisfies this for free as part of the WS upgrade
+     * handshake. If your WS host sits behind a proxy that drops non-upgrade
+     * HTTP on that path, make it answer *something*, or the browser will
+     * never attempt the WebSocket.
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -3846,21 +3850,26 @@ export class ThreeJSViewer {
     // ========== WebSocket ==========
 
     connect() {
-        // Derive HTTP probe URL from WS URL (same host/port)
+        // Derive the probe URL from the WS URL by swapping only the scheme
+        // (ws→http / wss→https). Path and query are preserved, so the probe
+        // targets the same endpoint as the eventual WebSocket upgrade.
         const probeUrl = this._wsUrl.replace(/^ws/, 'http');
 
         const doConnect = async () => {
             if (this._destroyed) return;
 
-            // Probe HTTP on the WS host:port before opening the WebSocket: a
-            // failed `new WebSocket()` always logs `WebSocket connection to
-            // '...' failed` to devtools and there's no way to silence it, so
-            // we only attempt the upgrade once we know something is listening.
-            // `mode: 'no-cors'` makes any HTTP response (200/404/426/...) count
-            // as success — only a TCP-level failure throws and triggers retry.
-            // The Python `websockets` server answers plain HTTP for free as part
-            // of the upgrade handshake; embedders pointing at a different WS host
-            // must ensure that host (or its proxy) returns *something* on GET.
+            // Probe HTTP on the same URL (minus scheme) as the pending
+            // WebSocket: a failed `new WebSocket()` always logs `WebSocket
+            // connection to '...' failed` to devtools and there's no way to
+            // silence it, so we only attempt the upgrade once we know
+            // something is listening. `mode: 'no-cors'` makes *any* HTTP
+            // response count as success (200/400/404/426/... — the exact
+            // status varies by server/proxy, all of them satisfy the probe);
+            // only a TCP-level failure throws and triggers retry. The Python
+            // `websockets` server answers plain HTTP for free as part of the
+            // upgrade handshake; embedders pointing at a different WS host
+            // must ensure that host (or its proxy) returns *something* on GET
+            // for the same path/query as `wsUrl`, not just for `/`.
             try {
                 await fetch(probeUrl, { mode: 'no-cors', signal: AbortSignal.timeout(400) });
             } catch {


### PR DESCRIPTION
## Summary

- Documents the (previously undocumented) HTTP probe contract that `ThreeJSViewer.connect()` requires of the WS host: a plain `GET` on the WS port must return *something* (any HTTP response, including 426), or the no-cors probe never resolves and the WebSocket is never attempted.
- The standard Python `websockets` server satisfies this for free as part of the upgrade handshake — but embedders pointing at a custom WS host or a strict reverse proxy can hit a silent "viewer never connects, no errors" failure, which just bit a downstream consumer.

## Changes

- **`viewer.js` constructor JSDoc** (`viewer.js:2105-2123`) — adds an "Embedding contract" paragraph explaining the probe.
- **`viewer.js` probe site comment** (`viewer.js:3848-3861`) — replaces the one-line "Probe first to avoid browser console warnings" with a fuller explanation of *why* the probe exists (browser logs failed-WS attempts with no API to silence) and what counts as success (any HTTP response, only TCP-level failure throws).
- **`DESIGN.md`** — adds an "Embedding the Viewer" section between "Viewer (Browser)" and "Message Protocol" covering the ES-module constructor signature, the WS-host probe contract, and the HTTP sidecar requirement on `port + 1`.
- **`viewer.html`** — regenerated via `viewer/build.py` to pick up the JS comment changes.

Docs-only; no behavior change.

## Test plan

- [ ] Skim DESIGN.md "Embedding the Viewer" section reads cleanly
- [ ] Confirm `viewer.html` diff is purely the JSDoc/comment changes from `viewer.js` (build is concat-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)