### PR TITLE
Lighting tuning: default exposure 1.0, runtime panel, Python init kwargs

### DIFF
--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -19,6 +19,11 @@ import numpy as np
 from websockets.sync.server import serve as sync_serve
 
 
+_ALLOWED_TONE_MAPPING_MODES = frozenset(
+    {"none", "linear", "reinhard", "cineon", "aces", "agx", "neutral"}
+)
+
+
 class _BlobHandler(BaseHTTPRequestHandler):
     """Serves binary blobs over HTTP for fast transfer to browser."""
 
@@ -52,6 +57,8 @@ class ViewerClient:
         open_browser: bool = True,
         tone_mapping_exposure: Optional[float] = None,
         environment_intensity: Optional[float] = None,
+        ambient_intensity: Optional[float] = None,
+        tone_mapping: Optional[str] = None,
     ):
         self.host = host
         self.port = port
@@ -62,6 +69,19 @@ class ViewerClient:
         # and wins over localStorage in the browser.
         self.tone_mapping_exposure = tone_mapping_exposure
         self.environment_intensity = environment_intensity
+        self.ambient_intensity = ambient_intensity
+        # Validate tone_mapping (case-insensitive, stored lowercase).  Matches
+        # the seven Three.js modes exposed in the viewer's lighting panel.
+        if tone_mapping is not None:
+            normalized = tone_mapping.lower()
+            if normalized not in _ALLOWED_TONE_MAPPING_MODES:
+                allowed = ", ".join(sorted(_ALLOWED_TONE_MAPPING_MODES))
+                raise ValueError(
+                    f"tone_mapping must be one of: {allowed} (got {tone_mapping!r})"
+                )
+            self.tone_mapping = normalized
+        else:
+            self.tone_mapping = None
         self._ws = None
         self._server = None
         self._server_thread = None
@@ -138,16 +158,21 @@ class ViewerClient:
     def viewer_url(self) -> str:
         """Full file:// URL to the viewer.
 
-        Always includes `ws_port`. Appends `tone_mapping_exposure` and/or
-        `environment_intensity` query params when the caller passed explicit
+        Always includes `ws_port`. Appends `tone_mapping`,
+        `tone_mapping_exposure`, `environment_intensity`, and/or
+        `ambient_intensity` query params when the caller passed explicit
         lighting overrides — those act as authoritative defaults in the
         browser (they win over the panel's localStorage on reload).
         """
         url = self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
+        if self.tone_mapping is not None:
+            url += f"&tone_mapping={self.tone_mapping}"
         if self.tone_mapping_exposure is not None:
             url += f"&tone_mapping_exposure={self.tone_mapping_exposure}"
         if self.environment_intensity is not None:
             url += f"&environment_intensity={self.environment_intensity}"
+        if self.ambient_intensity is not None:
+            url += f"&ambient_intensity={self.ambient_intensity}"
         return url
 
     def _run_server(self):

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -50,10 +50,18 @@ class ViewerClient:
         host: str = "localhost",
         port: int = 5666,
         open_browser: bool = True,
+        tone_mapping_exposure: Optional[float] = None,
+        environment_intensity: Optional[float] = None,
     ):
         self.host = host
         self.port = port
         self.open_browser = open_browser
+        # Lighting overrides — forwarded to the viewer via query string on launch.
+        # `None` means "not specified" (let the viewer pick its default or
+        # localStorage value). An explicit float (including 0.0) is authoritative
+        # and wins over localStorage in the browser.
+        self.tone_mapping_exposure = tone_mapping_exposure
+        self.environment_intensity = environment_intensity
         self._ws = None
         self._server = None
         self._server_thread = None
@@ -128,8 +136,19 @@ class ViewerClient:
 
     @property
     def viewer_url(self) -> str:
-        """Full file:// URL to the viewer, including ws_port query param."""
-        return self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
+        """Full file:// URL to the viewer.
+
+        Always includes `ws_port`. Appends `tone_mapping_exposure` and/or
+        `environment_intensity` query params when the caller passed explicit
+        lighting overrides — those act as authoritative defaults in the
+        browser (they win over the panel's localStorage on reload).
+        """
+        url = self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
+        if self.tone_mapping_exposure is not None:
+            url += f"&tone_mapping_exposure={self.tone_mapping_exposure}"
+        if self.environment_intensity is not None:
+            url += f"&environment_intensity={self.environment_intensity}"
+        return url
 
     def _run_server(self):
         """Run the WebSocket server in a background thread."""

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -7,8 +7,10 @@ Runs a WebSocket server that the browser connects to directly.
 
 import json
 import logging
+import math
 import threading
 import time
+import urllib.parse
 import uuid
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -22,6 +24,16 @@ from websockets.sync.server import serve as sync_serve
 _ALLOWED_TONE_MAPPING_MODES = frozenset(
     {"none", "linear", "reinhard", "cineon", "aces", "agx", "neutral"}
 )
+
+
+def _validate_finite(name: str, value: Optional[float]) -> Optional[float]:
+    """Reject NaN/Inf so they never leak into the query string."""
+    if value is None:
+        return None
+    f = float(value)
+    if not math.isfinite(f):
+        raise ValueError(f"{name} must be a finite number (got {value!r})")
+    return f
 
 
 class _BlobHandler(BaseHTTPRequestHandler):
@@ -66,10 +78,17 @@ class ViewerClient:
         # Lighting overrides — forwarded to the viewer via query string on launch.
         # `None` means "not specified" (let the viewer pick its default or
         # localStorage value). An explicit float (including 0.0) is authoritative
-        # and wins over localStorage in the browser.
-        self.tone_mapping_exposure = tone_mapping_exposure
-        self.environment_intensity = environment_intensity
-        self.ambient_intensity = ambient_intensity
+        # and wins over localStorage in the browser. Floats are validated eagerly
+        # so we never serialize NaN/Inf into the URL.
+        self.tone_mapping_exposure = _validate_finite(
+            "tone_mapping_exposure", tone_mapping_exposure
+        )
+        self.environment_intensity = _validate_finite(
+            "environment_intensity", environment_intensity
+        )
+        self.ambient_intensity = _validate_finite(
+            "ambient_intensity", ambient_intensity
+        )
         # Validate tone_mapping (case-insensitive, stored lowercase).  Matches
         # the seven Three.js modes exposed in the viewer's lighting panel.
         if tone_mapping is not None:
@@ -164,16 +183,16 @@ class ViewerClient:
         lighting overrides — those act as authoritative defaults in the
         browser (they win over the panel's localStorage on reload).
         """
-        url = self.viewer_path.resolve().as_uri() + f"?ws_port={self.port}"
+        params: list[tuple[str, str]] = [("ws_port", str(self.port))]
         if self.tone_mapping is not None:
-            url += f"&tone_mapping={self.tone_mapping}"
+            params.append(("tone_mapping", self.tone_mapping))
         if self.tone_mapping_exposure is not None:
-            url += f"&tone_mapping_exposure={self.tone_mapping_exposure}"
+            params.append(("tone_mapping_exposure", str(self.tone_mapping_exposure)))
         if self.environment_intensity is not None:
-            url += f"&environment_intensity={self.environment_intensity}"
+            params.append(("environment_intensity", str(self.environment_intensity)))
         if self.ambient_intensity is not None:
-            url += f"&ambient_intensity={self.ambient_intensity}"
-        return url
+            params.append(("ambient_intensity", str(self.ambient_intensity)))
+        return f"{self.viewer_path.resolve().as_uri()}?{urllib.parse.urlencode(params)}"
 
     def _run_server(self):
         """Run the WebSocket server in a background thread."""

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1292,16 +1292,19 @@ function toneMappingModes() {
 const TONE_MAPPING_MODE_NAMES = ['none', 'linear', 'reinhard', 'cineon', 'aces', 'agx', 'neutral'];
 
 /**
- * Resolve initial lighting values with precedence:
- *   URL param (`tone_mapping`, `tone_mapping_exposure`, `environment_intensity`, `ambient_intensity`)
- *   > options (`toneMapping`, `toneMappingExposure`, `environmentIntensity`, `ambientIntensity`)
- *   > localStorage (`tjsv.toneMapping`, `tjsv.toneMappingExposure`, `tjsv.environmentIntensity`, `tjsv.ambientIntensity`)
- *   > hard defaults.
+ * Resolve lighting values with two layered views:
  *
- * The returned object reports whether each effective value was *pinned* by
- * the URL/options layer — the panel's Reset button restores to that
- * effective initial value (not to localStorage), so URL-pinned values stick
- * across reloads even if the user has tweaked the panel on a previous visit.
+ *   `reset`  — the baseline the panel's Reset button restores to. Uses
+ *              URL param > options > hard defaults (localStorage is ignored
+ *              here, because "Reset" means "go back to the developer default
+ *              for this page load", not "re-apply the last session's tweak").
+ *   top-level — the effective initial values applied at startup and used
+ *              to seed the panel UI. Uses URL param > options > localStorage
+ *              > hard defaults.
+ *
+ * URL-pinned / option-pinned values end up identical in both views, so
+ * reloading a URL with `tone_mapping_exposure=2.3` sticks across reloads
+ * even if the user previously tweaked the panel.
  *
  * Invalid tone-mapping strings (not one of the seven known modes) and
  * non-finite numeric values silently fall through to the next level — we
@@ -1314,10 +1317,12 @@ const TONE_MAPPING_MODE_NAMES = ['none', 'linear', 'reinhard', 'cineon', 'aces',
  *     envIntensity: number,
  *     ambientIntensity: number,
  *     toneMapping: string,
- *     exposurePinned: boolean,
- *     envIntensityPinned: boolean,
- *     ambientIntensityPinned: boolean,
- *     toneMappingPinned: boolean,
+ *     reset: {
+ *         exposure: number,
+ *         envIntensity: number,
+ *         ambientIntensity: number,
+ *         toneMapping: string,
+ *     },
  * }}
  */
 function resolveLightingDefaults(options, urlParams) {
@@ -1352,6 +1357,22 @@ function resolveLightingDefaults(options, urlParams) {
         lsTm = parseToneMapping(localStorage.getItem(LS_KEY_TONE_MAPPING));
     } catch (e) { /* ignore storage errors */ }
 
+    // Reset baseline: URL > options > hard defaults (no localStorage).
+    const resetExposure = urlExp != null ? urlExp
+        : optExp != null ? optExp
+        : DEFAULT_TONE_MAPPING_EXPOSURE;
+    const resetEnvIntensity = urlEnv != null ? urlEnv
+        : optEnv != null ? optEnv
+        : DEFAULT_ENVIRONMENT_INTENSITY;
+    const resetAmbientIntensity = urlAmb != null ? urlAmb
+        : optAmb != null ? optAmb
+        : DEFAULT_AMBIENT_INTENSITY;
+    const resetToneMapping = urlTm != null ? urlTm
+        : optTm != null ? optTm
+        : DEFAULT_TONE_MAPPING;
+
+    // Effective initial: localStorage overlays the reset baseline, but only
+    // when URL/options haven't already pinned the value.
     const exposure = urlExp != null ? urlExp
         : optExp != null ? optExp
         : lsExp != null ? lsExp
@@ -1373,10 +1394,12 @@ function resolveLightingDefaults(options, urlParams) {
         envIntensity,
         ambientIntensity,
         toneMapping,
-        exposurePinned: urlExp != null || optExp != null,
-        envIntensityPinned: urlEnv != null || optEnv != null,
-        ambientIntensityPinned: urlAmb != null || optAmb != null,
-        toneMappingPinned: urlTm != null || optTm != null,
+        reset: {
+            exposure: resetExposure,
+            envIntensity: resetEnvIntensity,
+            ambientIntensity: resetAmbientIntensity,
+            toneMapping: resetToneMapping,
+        },
     };
 }
 
@@ -4090,8 +4113,12 @@ class ThreeJSViewer {
     }
 
     _resetLightingPanel() {
-        const d = this._lightingDefaults;
-        // Clear localStorage so next reload (without URL params) picks up hard defaults.
+        // Reset target: the pre-localStorage baseline (URL > options > hard
+        // defaults). Using _lightingDefaults directly would be a no-op when
+        // the page was seeded from localStorage, because localStorage already
+        // participated in that resolution — Reset is meant to *escape* the
+        // user's persisted tweaks, not re-apply them.
+        const d = this._lightingDefaults.reset;
         try { localStorage.removeItem(LS_KEY_TONE_MAPPING_EXPOSURE); } catch (e) { /* ignore */ }
         try { localStorage.removeItem(LS_KEY_ENVIRONMENT_INTENSITY); } catch (e) { /* ignore */ }
         try { localStorage.removeItem(LS_KEY_AMBIENT_INTENSITY); } catch (e) { /* ignore */ }

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -3530,7 +3530,9 @@ class ThreeJSViewer {
         this._renderer = new THREE.WebGLRenderer({ antialias: true });
         this._renderer.setSize(w, h);
         this._renderer.setPixelRatio(window.devicePixelRatio);
-        this._renderer.toneMapping = toneMappingModes()[this._lightingDefaults.toneMapping];
+        this._renderer.toneMapping = /** @type {THREE.ToneMapping} */ (
+            toneMappingModes()[this._lightingDefaults.toneMapping]
+        );
         this._renderer.toneMappingExposure = this._lightingDefaults.exposure;
         this._renderer.localClippingEnabled = true;
         this.el.appendChild(this._renderer.domElement);
@@ -4069,7 +4071,7 @@ class ThreeJSViewer {
     _applyToneMapping(mode) {
         const modes = toneMappingModes();
         if (!(mode in modes)) return;
-        this._renderer.toneMapping = modes[mode];
+        this._renderer.toneMapping = /** @type {THREE.ToneMapping} */ (modes[mode]);
         // Flush shaders on every material currently in the scene so they
         // recompile against the new tone-mapping constant.
         this._scene.traverse((obj) => {

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -420,6 +420,25 @@
             min-width: 52px;
             text-align: right;
         }
+        .threejs-viewer .lighting-select-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .threejs-viewer .lighting-select-row select {
+            flex: 1;
+            background: #2a2a2a;
+            color: white;
+            border: 1px solid #444;
+            border-radius: 4px;
+            padding: 4px 6px;
+            font-size: 12px;
+            cursor: pointer;
+        }
+        .threejs-viewer .lighting-select-row select:focus {
+            outline: none;
+            border-color: #0066cc;
+        }
         .threejs-viewer .lighting-actions {
             display: flex;
             justify-content: flex-end;
@@ -520,6 +539,20 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
 <div class="tjsv-lighting-panel">
     <h3>Lighting <button class="tjsv-lighting-close" title="Close (E)">&times;</button></h3>
     <div class="lighting-section">
+        <label>Tone mapping</label>
+        <div class="lighting-select-row">
+            <select class="tjsv-lighting-tone-mapping">
+                <option value="none">None</option>
+                <option value="linear">Linear</option>
+                <option value="reinhard">Reinhard</option>
+                <option value="cineon">Cineon</option>
+                <option value="aces" selected>ACES Filmic</option>
+                <option value="agx">AgX</option>
+                <option value="neutral">Neutral</option>
+            </select>
+        </div>
+    </div>
+    <div class="lighting-section">
         <label>Tone mapping exposure</label>
         <div class="lighting-slider-row">
             <input type="range" class="tjsv-lighting-exposure" min="0" max="3" step="0.05" value="1">
@@ -531,6 +564,13 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
         <div class="lighting-slider-row">
             <input type="range" class="tjsv-lighting-env" min="0" max="4" step="0.05" value="2">
             <span class="lighting-value tjsv-lighting-env-value">2.00</span>
+        </div>
+    </div>
+    <div class="lighting-section">
+        <label>Ambient intensity</label>
+        <div class="lighting-slider-row">
+            <input type="range" class="tjsv-lighting-ambient" min="0" max="3" step="0.05" value="1.5">
+            <span class="lighting-value tjsv-lighting-ambient-value">1.50</span>
         </div>
     </div>
     <div class="lighting-actions">
@@ -1225,27 +1265,60 @@ function makeChannelApply(viewer) {
     };
 }
 
-// Default lighting values. Panel ranges: exposure 0.0–3.0, env intensity 0.0–4.0.
+// Default lighting values. Panel ranges: exposure 0.0–3.0, env intensity 0.0–4.0, ambient 0.0–3.0.
 const DEFAULT_TONE_MAPPING_EXPOSURE = 1.0;
 const DEFAULT_ENVIRONMENT_INTENSITY = 2.0;
+const DEFAULT_AMBIENT_INTENSITY = 1.5;
+const DEFAULT_TONE_MAPPING = 'aces';
 const LS_KEY_TONE_MAPPING_EXPOSURE = 'tjsv.toneMappingExposure';
 const LS_KEY_ENVIRONMENT_INTENSITY = 'tjsv.environmentIntensity';
+const LS_KEY_AMBIENT_INTENSITY = 'tjsv.ambientIntensity';
+const LS_KEY_TONE_MAPPING = 'tjsv.toneMapping';
+
+// Tone-mapping mode name -> THREE.* constant. Resolved lazily so THREE only
+// needs to be loaded when the viewer actually instantiates.
+/** @returns {Record<string, number>} */
+function toneMappingModes() {
+    return {
+        none: THREE.NoToneMapping,
+        linear: THREE.LinearToneMapping,
+        reinhard: THREE.ReinhardToneMapping,
+        cineon: THREE.CineonToneMapping,
+        aces: THREE.ACESFilmicToneMapping,
+        agx: THREE.AgXToneMapping,
+        neutral: THREE.NeutralToneMapping,
+    };
+}
+const TONE_MAPPING_MODE_NAMES = ['none', 'linear', 'reinhard', 'cineon', 'aces', 'agx', 'neutral'];
 
 /**
  * Resolve initial lighting values with precedence:
- *   URL param (`tone_mapping_exposure`, `environment_intensity`)
- *   > options (`toneMappingExposure`, `environmentIntensity`)
- *   > localStorage (`tjsv.toneMappingExposure`, `tjsv.environmentIntensity`)
+ *   URL param (`tone_mapping`, `tone_mapping_exposure`, `environment_intensity`, `ambient_intensity`)
+ *   > options (`toneMapping`, `toneMappingExposure`, `environmentIntensity`, `ambientIntensity`)
+ *   > localStorage (`tjsv.toneMapping`, `tjsv.toneMappingExposure`, `tjsv.environmentIntensity`, `tjsv.ambientIntensity`)
  *   > hard defaults.
  *
- * The returned object reports whether the effective value was *pinned* by the
- * URL/options layer — the panel's Reset button restores to that effective
- * initial value (not to localStorage), so URL-pinned values stick across
- * reloads even if the user has tweaked the panel on a previous visit.
+ * The returned object reports whether each effective value was *pinned* by
+ * the URL/options layer — the panel's Reset button restores to that
+ * effective initial value (not to localStorage), so URL-pinned values stick
+ * across reloads even if the user has tweaked the panel on a previous visit.
+ *
+ * Invalid tone-mapping strings (not one of the seven known modes) and
+ * non-finite numeric values silently fall through to the next level — we
+ * never throw in the browser here; Python already validates its kwargs.
  *
  * @param {Object} options
  * @param {URLSearchParams} urlParams
- * @returns {{exposure: number, envIntensity: number, exposurePinned: boolean, envIntensityPinned: boolean}}
+ * @returns {{
+ *     exposure: number,
+ *     envIntensity: number,
+ *     ambientIntensity: number,
+ *     toneMapping: string,
+ *     exposurePinned: boolean,
+ *     envIntensityPinned: boolean,
+ *     ambientIntensityPinned: boolean,
+ *     toneMappingPinned: boolean,
+ * }}
  */
 function resolveLightingDefaults(options, urlParams) {
     /** @type {(raw: (string|null|number|undefined)) => (number|null)} */
@@ -1254,15 +1327,29 @@ function resolveLightingDefaults(options, urlParams) {
         const n = typeof raw === 'number' ? raw : parseFloat(raw);
         return Number.isFinite(n) ? n : null;
     };
+    /** @type {(raw: (string|null|undefined)) => (string|null)} */
+    const parseToneMapping = (raw) => {
+        if (raw === null || raw === undefined || raw === '') return null;
+        const s = String(raw).toLowerCase();
+        return TONE_MAPPING_MODE_NAMES.includes(s) ? s : null;
+    };
     const urlExp = parseFinite(urlParams.get('tone_mapping_exposure'));
     const urlEnv = parseFinite(urlParams.get('environment_intensity'));
+    const urlAmb = parseFinite(urlParams.get('ambient_intensity'));
+    const urlTm = parseToneMapping(urlParams.get('tone_mapping'));
     const optExp = parseFinite(options.toneMappingExposure);
     const optEnv = parseFinite(options.environmentIntensity);
+    const optAmb = parseFinite(options.ambientIntensity);
+    const optTm = parseToneMapping(options.toneMapping);
     let lsExp = null;
     let lsEnv = null;
+    let lsAmb = null;
+    let lsTm = null;
     try {
         lsExp = parseFinite(localStorage.getItem(LS_KEY_TONE_MAPPING_EXPOSURE));
         lsEnv = parseFinite(localStorage.getItem(LS_KEY_ENVIRONMENT_INTENSITY));
+        lsAmb = parseFinite(localStorage.getItem(LS_KEY_AMBIENT_INTENSITY));
+        lsTm = parseToneMapping(localStorage.getItem(LS_KEY_TONE_MAPPING));
     } catch (e) { /* ignore storage errors */ }
 
     const exposure = urlExp != null ? urlExp
@@ -1273,11 +1360,23 @@ function resolveLightingDefaults(options, urlParams) {
         : optEnv != null ? optEnv
         : lsEnv != null ? lsEnv
         : DEFAULT_ENVIRONMENT_INTENSITY;
+    const ambientIntensity = urlAmb != null ? urlAmb
+        : optAmb != null ? optAmb
+        : lsAmb != null ? lsAmb
+        : DEFAULT_AMBIENT_INTENSITY;
+    const toneMapping = urlTm != null ? urlTm
+        : optTm != null ? optTm
+        : lsTm != null ? lsTm
+        : DEFAULT_TONE_MAPPING;
     return {
         exposure,
         envIntensity,
+        ambientIntensity,
+        toneMapping,
         exposurePinned: urlExp != null || optExp != null,
         envIntensityPinned: urlEnv != null || optEnv != null,
+        ambientIntensityPinned: urlAmb != null || optAmb != null,
+        toneMappingPinned: urlTm != null || optTm != null,
     };
 }
 
@@ -3151,6 +3250,8 @@ class ThreeJSViewer {
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
      * @param {number}  [options.toneMappingExposure] - Override renderer tone-mapping exposure (default 1.0)
      * @param {number}  [options.environmentIntensity] - Override scene environment intensity (default 2.0)
+     * @param {number}  [options.ambientIntensity] - Override ambient-light intensity (default 1.5)
+     * @param {string}  [options.toneMapping] - Tone-mapping mode: one of none/linear/reinhard/cineon/aces/agx/neutral (default "aces")
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -3299,6 +3400,9 @@ class ThreeJSViewer {
         this._lightingExposureValue = q('.tjsv-lighting-exposure-value');
         this._lightingEnvSlider = q('.tjsv-lighting-env');
         this._lightingEnvValue = q('.tjsv-lighting-env-value');
+        this._lightingAmbientSlider = q('.tjsv-lighting-ambient');
+        this._lightingAmbientValue = q('.tjsv-lighting-ambient-value');
+        this._lightingToneMappingSelect = q('.tjsv-lighting-tone-mapping');
         this._lightingResetBtn = q('.tjsv-lighting-reset');
         this._lightingCloseBtn = q('.tjsv-lighting-close');
         this._clipDistanceSlider = q('.tjsv-clip-distance');
@@ -3355,7 +3459,7 @@ class ThreeJSViewer {
         this._renderer = new THREE.WebGLRenderer({ antialias: true });
         this._renderer.setSize(w, h);
         this._renderer.setPixelRatio(window.devicePixelRatio);
-        this._renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this._renderer.toneMapping = toneMappingModes()[this._lightingDefaults.toneMapping];
         this._renderer.toneMappingExposure = this._lightingDefaults.exposure;
         this._renderer.localClippingEnabled = true;
         this.el.appendChild(this._renderer.domElement);
@@ -3503,9 +3607,9 @@ class ThreeJSViewer {
             this.frameObject(target);
         });
 
-        // Lighting
-        const ambientLight = new THREE.AmbientLight(0xffffff, 1.5);
-        this._scene.add(ambientLight);
+        // Lighting — kept as an instance ref so the Lighting panel can tune intensity at runtime.
+        this._ambientLight = new THREE.AmbientLight(0xffffff, this._lightingDefaults.ambientIntensity);
+        this._scene.add(this._ambientLight);
 
         // Grid helper on XY plane (Z-up) — hidden by default
         this._gridHelper = new THREE.GridHelper(10, 10);
@@ -3876,6 +3980,38 @@ class ThreeJSViewer {
         this._scene.environmentIntensity = value;
     }
 
+    _applyAmbientIntensity(value) {
+        if (this._ambientLight) this._ambientLight.intensity = value;
+    }
+
+    /**
+     * Set the renderer tone-mapping mode and flush every material's shader.
+     *
+     * Three.js bakes `renderer.toneMapping` into each material's shader at
+     * compile time, so changing the renderer value alone has no visible
+     * effect on already-compiled materials. Setting `material.needsUpdate =
+     * true` marks the program for recompilation on the next draw, which is
+     * the documented invalidation path in three.js 0.183.
+     *
+     * @param {string} mode - one of the keys in toneMappingModes().
+     */
+    _applyToneMapping(mode) {
+        const modes = toneMappingModes();
+        if (!(mode in modes)) return;
+        this._renderer.toneMapping = modes[mode];
+        // Flush shaders on every material currently in the scene so they
+        // recompile against the new tone-mapping constant.
+        this._scene.traverse((obj) => {
+            const mat = /** @type {any} */ (obj).material;
+            if (!mat) return;
+            if (Array.isArray(mat)) {
+                for (const m of mat) { if (m) m.needsUpdate = true; }
+            } else {
+                mat.needsUpdate = true;
+            }
+        });
+    }
+
     _writeLightingLocalStorage(key, value) {
         try { localStorage.setItem(key, String(value)); } catch (e) { /* ignore quota */ }
     }
@@ -3885,25 +4021,41 @@ class ThreeJSViewer {
         // Clear localStorage so next reload (without URL params) picks up hard defaults.
         try { localStorage.removeItem(LS_KEY_TONE_MAPPING_EXPOSURE); } catch (e) { /* ignore */ }
         try { localStorage.removeItem(LS_KEY_ENVIRONMENT_INTENSITY); } catch (e) { /* ignore */ }
+        try { localStorage.removeItem(LS_KEY_AMBIENT_INTENSITY); } catch (e) { /* ignore */ }
+        try { localStorage.removeItem(LS_KEY_TONE_MAPPING); } catch (e) { /* ignore */ }
+        this._applyToneMapping(d.toneMapping);
         this._applyToneMappingExposure(d.exposure);
         this._applyEnvironmentIntensity(d.envIntensity);
+        this._applyAmbientIntensity(d.ambientIntensity);
+        this._lightingToneMappingSelect.value = d.toneMapping;
         this._lightingExposureSlider.value = String(d.exposure);
         this._lightingExposureValue.textContent = d.exposure.toFixed(2);
         this._lightingEnvSlider.value = String(d.envIntensity);
         this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+        this._lightingAmbientSlider.value = String(d.ambientIntensity);
+        this._lightingAmbientValue.textContent = d.ambientIntensity.toFixed(2);
     }
 
     _initLightingPanelUI() {
         const d = this._lightingDefaults;
         // Seed sliders/readouts with the effective initial values.
+        this._lightingToneMappingSelect.value = d.toneMapping;
         this._lightingExposureSlider.value = String(d.exposure);
         this._lightingExposureValue.textContent = d.exposure.toFixed(2);
         this._lightingEnvSlider.value = String(d.envIntensity);
         this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+        this._lightingAmbientSlider.value = String(d.ambientIntensity);
+        this._lightingAmbientValue.textContent = d.ambientIntensity.toFixed(2);
 
         this._btnLighting.addEventListener('click', () => this._toggleLightingPanel());
         this._lightingCloseBtn.addEventListener('click', () => this._toggleLightingPanel());
 
+        this._lightingToneMappingSelect.addEventListener('change', () => {
+            const mode = this._lightingToneMappingSelect.value;
+            if (!TONE_MAPPING_MODE_NAMES.includes(mode)) return;
+            this._applyToneMapping(mode);
+            this._writeLightingLocalStorage(LS_KEY_TONE_MAPPING, mode);
+        });
         this._lightingExposureSlider.addEventListener('input', () => {
             const v = parseFloat(this._lightingExposureSlider.value);
             if (!Number.isFinite(v)) return;
@@ -3917,6 +4069,13 @@ class ThreeJSViewer {
             this._applyEnvironmentIntensity(v);
             this._lightingEnvValue.textContent = v.toFixed(2);
             this._writeLightingLocalStorage(LS_KEY_ENVIRONMENT_INTENSITY, v);
+        });
+        this._lightingAmbientSlider.addEventListener('input', () => {
+            const v = parseFloat(this._lightingAmbientSlider.value);
+            if (!Number.isFinite(v)) return;
+            this._applyAmbientIntensity(v);
+            this._lightingAmbientValue.textContent = v.toFixed(2);
+            this._writeLightingLocalStorage(LS_KEY_AMBIENT_INTENSITY, v);
         });
         this._lightingResetBtn.addEventListener('click', () => this._resetLightingPanel());
     }

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -357,6 +357,88 @@
             color: #999;
             text-align: center;
         }
+
+        /* Lighting Panel */
+        .threejs-viewer .tjsv-lighting-panel {
+            position: absolute;
+            bottom: 10px;
+            right: 10px;
+            background: rgba(30, 30, 30, 0.95);
+            color: white;
+            padding: 14px;
+            border-radius: 8px;
+            font-size: 13px;
+            display: none;
+            flex-direction: column;
+            gap: 10px;
+            min-width: 240px;
+            user-select: none;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+        }
+        .threejs-viewer .tjsv-lighting-panel.visible { display: flex; }
+        .threejs-viewer .tjsv-lighting-panel h3 {
+            margin: 0;
+            font-size: 13px;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .threejs-viewer .tjsv-lighting-panel h3 button {
+            background: none;
+            border: none;
+            color: #888;
+            font-size: 16px;
+            cursor: pointer;
+            padding: 0 2px;
+            line-height: 1;
+        }
+        .threejs-viewer .tjsv-lighting-panel h3 button:hover { color: white; }
+        .threejs-viewer .lighting-section {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .threejs-viewer .lighting-section label {
+            font-size: 11px;
+            color: #aaa;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .threejs-viewer .lighting-slider-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .threejs-viewer .lighting-slider-row input[type="range"] {
+            flex: 1;
+            accent-color: #0066cc;
+        }
+        .threejs-viewer .lighting-slider-row .lighting-value {
+            font-family: monospace;
+            font-size: 12px;
+            min-width: 52px;
+            text-align: right;
+        }
+        .threejs-viewer .lighting-actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+        .threejs-viewer .lighting-actions .tjsv-lighting-reset {
+            background: #444;
+            border: none;
+            color: white;
+            padding: 6px 14px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+        }
+        .threejs-viewer .lighting-actions .tjsv-lighting-reset:hover { background: #555; }
+        .threejs-viewer .lighting-hint {
+            font-size: 10px;
+            color: #999;
+            text-align: center;
+        }
     </style>
     <script type="importmap">
     {
@@ -384,6 +466,7 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
     <span class="tjsv-status-text">Disconnected</span>
     <div class="toolbar-sep"></div>
     <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane">&#x2702; C</button>
+    <button class="toolbar-btn tjsv-btn-lighting" title="Lighting / exposure (E)">&#x263C; E</button>
     <button class="toolbar-btn tjsv-btn-ortho" title="Orthographic / Perspective (O)">&#x2B1A; O</button>
     <button class="toolbar-btn tjsv-btn-orbit-mode" title="Orbit mode (R)">&#x27F3; R</button>
     <button class="toolbar-btn tjsv-btn-track" title="Camera tracking" style="display:none">&#x229A; T</button>
@@ -432,6 +515,28 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
         </div>
     </div>
     <div class="clip-hint">C: toggle | S: slab | V: view normal | H: helper | &larr;&rarr;: position | &uarr;&darr;: thickness</div>
+</div>
+
+<div class="tjsv-lighting-panel">
+    <h3>Lighting <button class="tjsv-lighting-close" title="Close (E)">&times;</button></h3>
+    <div class="lighting-section">
+        <label>Tone mapping exposure</label>
+        <div class="lighting-slider-row">
+            <input type="range" class="tjsv-lighting-exposure" min="0" max="3" step="0.05" value="1">
+            <span class="lighting-value tjsv-lighting-exposure-value">1.00</span>
+        </div>
+    </div>
+    <div class="lighting-section">
+        <label>Environment intensity</label>
+        <div class="lighting-slider-row">
+            <input type="range" class="tjsv-lighting-env" min="0" max="4" step="0.05" value="2">
+            <span class="lighting-value tjsv-lighting-env-value">2.00</span>
+        </div>
+    </div>
+    <div class="lighting-actions">
+        <button class="tjsv-lighting-reset" title="Reset to initial values">Reset</button>
+    </div>
+    <div class="lighting-hint">E: toggle | values persist in localStorage</div>
 </div>
 
 <div class="tjsv-animation-controls">
@@ -1117,6 +1222,62 @@ function makeChannelApply(viewer) {
         // No-ops: data is read directly in _applyCameraTracking, not per-object
         camera_target: () => {},
         camera_position: () => {},
+    };
+}
+
+// Default lighting values. Panel ranges: exposure 0.0–3.0, env intensity 0.0–4.0.
+const DEFAULT_TONE_MAPPING_EXPOSURE = 1.0;
+const DEFAULT_ENVIRONMENT_INTENSITY = 2.0;
+const LS_KEY_TONE_MAPPING_EXPOSURE = 'tjsv.toneMappingExposure';
+const LS_KEY_ENVIRONMENT_INTENSITY = 'tjsv.environmentIntensity';
+
+/**
+ * Resolve initial lighting values with precedence:
+ *   URL param (`tone_mapping_exposure`, `environment_intensity`)
+ *   > options (`toneMappingExposure`, `environmentIntensity`)
+ *   > localStorage (`tjsv.toneMappingExposure`, `tjsv.environmentIntensity`)
+ *   > hard defaults.
+ *
+ * The returned object reports whether the effective value was *pinned* by the
+ * URL/options layer — the panel's Reset button restores to that effective
+ * initial value (not to localStorage), so URL-pinned values stick across
+ * reloads even if the user has tweaked the panel on a previous visit.
+ *
+ * @param {Object} options
+ * @param {URLSearchParams} urlParams
+ * @returns {{exposure: number, envIntensity: number, exposurePinned: boolean, envIntensityPinned: boolean}}
+ */
+function resolveLightingDefaults(options, urlParams) {
+    /** @type {(raw: (string|null|number|undefined)) => (number|null)} */
+    const parseFinite = (raw) => {
+        if (raw === null || raw === undefined || raw === '') return null;
+        const n = typeof raw === 'number' ? raw : parseFloat(raw);
+        return Number.isFinite(n) ? n : null;
+    };
+    const urlExp = parseFinite(urlParams.get('tone_mapping_exposure'));
+    const urlEnv = parseFinite(urlParams.get('environment_intensity'));
+    const optExp = parseFinite(options.toneMappingExposure);
+    const optEnv = parseFinite(options.environmentIntensity);
+    let lsExp = null;
+    let lsEnv = null;
+    try {
+        lsExp = parseFinite(localStorage.getItem(LS_KEY_TONE_MAPPING_EXPOSURE));
+        lsEnv = parseFinite(localStorage.getItem(LS_KEY_ENVIRONMENT_INTENSITY));
+    } catch (e) { /* ignore storage errors */ }
+
+    const exposure = urlExp != null ? urlExp
+        : optExp != null ? optExp
+        : lsExp != null ? lsExp
+        : DEFAULT_TONE_MAPPING_EXPOSURE;
+    const envIntensity = urlEnv != null ? urlEnv
+        : optEnv != null ? optEnv
+        : lsEnv != null ? lsEnv
+        : DEFAULT_ENVIRONMENT_INTENSITY;
+    return {
+        exposure,
+        envIntensity,
+        exposurePinned: urlExp != null || optExp != null,
+        envIntensityPinned: urlEnv != null || optEnv != null,
     };
 }
 
@@ -2988,6 +3149,8 @@ class ThreeJSViewer {
      * @param {boolean} [options.autoConnect=true] - Whether to connect WebSocket immediately
      * @param {string}  [options.htmlTemplate] - HTML template string for UI controls
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
+     * @param {number}  [options.toneMappingExposure] - Override renderer tone-mapping exposure (default 1.0)
+     * @param {number}  [options.environmentIntensity] - Override scene environment intensity (default 2.0)
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -3024,6 +3187,11 @@ class ThreeJSViewer {
             const port = options.wsPort || parseInt(urlParams.get('ws_port')) || 5666;
             this._wsUrl = `ws://localhost:${port}`;
         }
+
+        // Resolve lighting defaults. Precedence: URL param > options > localStorage > hard default.
+        // URL param is always authoritative (developer's explicit choice) — panel edits go to
+        // localStorage but don't override a URL-provided value on reload.
+        this._lightingDefaults = resolveLightingDefaults(options, urlParams);
 
         // State
         this._objects = new Map();
@@ -3124,7 +3292,15 @@ class ThreeJSViewer {
         this._btnOrtho = q('.tjsv-btn-ortho');
         this._btnOrbitMode = q('.tjsv-btn-orbit-mode');
         this._btnClip = q('.tjsv-btn-clip');
+        this._btnLighting = q('.tjsv-btn-lighting');
         this._clipPanelEl = q('.tjsv-clipping-panel');
+        this._lightingPanelEl = q('.tjsv-lighting-panel');
+        this._lightingExposureSlider = q('.tjsv-lighting-exposure');
+        this._lightingExposureValue = q('.tjsv-lighting-exposure-value');
+        this._lightingEnvSlider = q('.tjsv-lighting-env');
+        this._lightingEnvValue = q('.tjsv-lighting-env-value');
+        this._lightingResetBtn = q('.tjsv-lighting-reset');
+        this._lightingCloseBtn = q('.tjsv-lighting-close');
         this._clipDistanceSlider = q('.tjsv-clip-distance');
         this._clipDistanceValue = q('.tjsv-clip-distance-value');
         this._clipThicknessSlider = q('.tjsv-clip-thickness');
@@ -3180,7 +3356,7 @@ class ThreeJSViewer {
         this._renderer.setSize(w, h);
         this._renderer.setPixelRatio(window.devicePixelRatio);
         this._renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this._renderer.toneMappingExposure = 1.5;
+        this._renderer.toneMappingExposure = this._lightingDefaults.exposure;
         this._renderer.localClippingEnabled = true;
         this.el.appendChild(this._renderer.domElement);
 
@@ -3385,7 +3561,7 @@ class ThreeJSViewer {
                     cubeTexture.needsUpdate = true;
                     const envMap = pmremGenerator.fromCubemap(cubeTexture).texture;
                     scene.environment = envMap;
-                    scene.environmentIntensity = 2.0;
+                    scene.environmentIntensity = this._lightingDefaults.envIntensity;
                     cubeTexture.dispose();
                     pmremGenerator.dispose();
                 }
@@ -3683,6 +3859,66 @@ class ThreeJSViewer {
         this._clipPanelEl.querySelectorAll('.clip-axis-buttons button').forEach(btn => {
             btn.classList.remove('active');
         });
+    }
+
+    // ========== Lighting Panel ==========
+
+    _toggleLightingPanel() {
+        const visible = this._lightingPanelEl.classList.toggle('visible');
+        this._btnLighting.classList.toggle('active', visible);
+    }
+
+    _applyToneMappingExposure(value) {
+        this._renderer.toneMappingExposure = value;
+    }
+
+    _applyEnvironmentIntensity(value) {
+        this._scene.environmentIntensity = value;
+    }
+
+    _writeLightingLocalStorage(key, value) {
+        try { localStorage.setItem(key, String(value)); } catch (e) { /* ignore quota */ }
+    }
+
+    _resetLightingPanel() {
+        const d = this._lightingDefaults;
+        // Clear localStorage so next reload (without URL params) picks up hard defaults.
+        try { localStorage.removeItem(LS_KEY_TONE_MAPPING_EXPOSURE); } catch (e) { /* ignore */ }
+        try { localStorage.removeItem(LS_KEY_ENVIRONMENT_INTENSITY); } catch (e) { /* ignore */ }
+        this._applyToneMappingExposure(d.exposure);
+        this._applyEnvironmentIntensity(d.envIntensity);
+        this._lightingExposureSlider.value = String(d.exposure);
+        this._lightingExposureValue.textContent = d.exposure.toFixed(2);
+        this._lightingEnvSlider.value = String(d.envIntensity);
+        this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+    }
+
+    _initLightingPanelUI() {
+        const d = this._lightingDefaults;
+        // Seed sliders/readouts with the effective initial values.
+        this._lightingExposureSlider.value = String(d.exposure);
+        this._lightingExposureValue.textContent = d.exposure.toFixed(2);
+        this._lightingEnvSlider.value = String(d.envIntensity);
+        this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+
+        this._btnLighting.addEventListener('click', () => this._toggleLightingPanel());
+        this._lightingCloseBtn.addEventListener('click', () => this._toggleLightingPanel());
+
+        this._lightingExposureSlider.addEventListener('input', () => {
+            const v = parseFloat(this._lightingExposureSlider.value);
+            if (!Number.isFinite(v)) return;
+            this._applyToneMappingExposure(v);
+            this._lightingExposureValue.textContent = v.toFixed(2);
+            this._writeLightingLocalStorage(LS_KEY_TONE_MAPPING_EXPOSURE, v);
+        });
+        this._lightingEnvSlider.addEventListener('input', () => {
+            const v = parseFloat(this._lightingEnvSlider.value);
+            if (!Number.isFinite(v)) return;
+            this._applyEnvironmentIntensity(v);
+            this._lightingEnvValue.textContent = v.toFixed(2);
+            this._writeLightingLocalStorage(LS_KEY_ENVIRONMENT_INTENSITY, v);
+        });
+        this._lightingResetBtn.addEventListener('click', () => this._resetLightingPanel());
     }
 
     // ========== Camera ==========
@@ -4476,6 +4712,9 @@ class ThreeJSViewer {
         // Clip button
         this._btnClip.addEventListener('click', () => this._toggleClipPanel());
 
+        // Lighting panel
+        this._initLightingPanelUI();
+
         // Clip axis buttons
         this._clipPanelEl.querySelectorAll('.clip-axis-buttons button').forEach(btn => {
             btn.addEventListener('click', () => this._setClipAxis(btn.dataset.axis));
@@ -4586,6 +4825,10 @@ class ThreeJSViewer {
             }
             if (e.code === 'KeyC' && !e.ctrlKey && !e.metaKey) {
                 this._toggleClipPanel();
+                return;
+            }
+            if (e.code === 'KeyE' && !e.ctrlKey && !e.metaKey) {
+                this._toggleLightingPanel();
                 return;
             }
             if (e.code === 'KeyM' && !e.ctrlKey && !e.metaKey) {

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -57,6 +57,20 @@
 <div class="tjsv-lighting-panel">
     <h3>Lighting <button class="tjsv-lighting-close" title="Close (E)">&times;</button></h3>
     <div class="lighting-section">
+        <label>Tone mapping</label>
+        <div class="lighting-select-row">
+            <select class="tjsv-lighting-tone-mapping">
+                <option value="none">None</option>
+                <option value="linear">Linear</option>
+                <option value="reinhard">Reinhard</option>
+                <option value="cineon">Cineon</option>
+                <option value="aces" selected>ACES Filmic</option>
+                <option value="agx">AgX</option>
+                <option value="neutral">Neutral</option>
+            </select>
+        </div>
+    </div>
+    <div class="lighting-section">
         <label>Tone mapping exposure</label>
         <div class="lighting-slider-row">
             <input type="range" class="tjsv-lighting-exposure" min="0" max="3" step="0.05" value="1">
@@ -68,6 +82,13 @@
         <div class="lighting-slider-row">
             <input type="range" class="tjsv-lighting-env" min="0" max="4" step="0.05" value="2">
             <span class="lighting-value tjsv-lighting-env-value">2.00</span>
+        </div>
+    </div>
+    <div class="lighting-section">
+        <label>Ambient intensity</label>
+        <div class="lighting-slider-row">
+            <input type="range" class="tjsv-lighting-ambient" min="0" max="3" step="0.05" value="1.5">
+            <span class="lighting-value tjsv-lighting-ambient-value">1.50</span>
         </div>
     </div>
     <div class="lighting-actions">

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -3,6 +3,7 @@
     <span class="tjsv-status-text">Disconnected</span>
     <div class="toolbar-sep"></div>
     <button class="toolbar-btn tjsv-btn-clip" title="Clipping Plane">&#x2702; C</button>
+    <button class="toolbar-btn tjsv-btn-lighting" title="Lighting / exposure (E)">&#x263C; E</button>
     <button class="toolbar-btn tjsv-btn-ortho" title="Orthographic / Perspective (O)">&#x2B1A; O</button>
     <button class="toolbar-btn tjsv-btn-orbit-mode" title="Orbit mode (R)">&#x27F3; R</button>
     <button class="toolbar-btn tjsv-btn-track" title="Camera tracking" style="display:none">&#x229A; T</button>
@@ -51,6 +52,28 @@
         </div>
     </div>
     <div class="clip-hint">C: toggle | S: slab | V: view normal | H: helper | &larr;&rarr;: position | &uarr;&darr;: thickness</div>
+</div>
+
+<div class="tjsv-lighting-panel">
+    <h3>Lighting <button class="tjsv-lighting-close" title="Close (E)">&times;</button></h3>
+    <div class="lighting-section">
+        <label>Tone mapping exposure</label>
+        <div class="lighting-slider-row">
+            <input type="range" class="tjsv-lighting-exposure" min="0" max="3" step="0.05" value="1">
+            <span class="lighting-value tjsv-lighting-exposure-value">1.00</span>
+        </div>
+    </div>
+    <div class="lighting-section">
+        <label>Environment intensity</label>
+        <div class="lighting-slider-row">
+            <input type="range" class="tjsv-lighting-env" min="0" max="4" step="0.05" value="2">
+            <span class="lighting-value tjsv-lighting-env-value">2.00</span>
+        </div>
+    </div>
+    <div class="lighting-actions">
+        <button class="tjsv-lighting-reset" title="Reset to initial values">Reset</button>
+    </div>
+    <div class="lighting-hint">E: toggle | values persist in localStorage</div>
 </div>
 
 <div class="tjsv-animation-controls">

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -409,6 +409,25 @@
     min-width: 52px;
     text-align: right;
 }
+.threejs-viewer .lighting-select-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.threejs-viewer .lighting-select-row select {
+    flex: 1;
+    background: #2a2a2a;
+    color: white;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 4px 6px;
+    font-size: 12px;
+    cursor: pointer;
+}
+.threejs-viewer .lighting-select-row select:focus {
+    outline: none;
+    border-color: #0066cc;
+}
 .threejs-viewer .lighting-actions {
     display: flex;
     justify-content: flex-end;

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -346,3 +346,85 @@
     color: #999;
     text-align: center;
 }
+
+/* Lighting Panel */
+.threejs-viewer .tjsv-lighting-panel {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background: rgba(30, 30, 30, 0.95);
+    color: white;
+    padding: 14px;
+    border-radius: 8px;
+    font-size: 13px;
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 240px;
+    user-select: none;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+}
+.threejs-viewer .tjsv-lighting-panel.visible { display: flex; }
+.threejs-viewer .tjsv-lighting-panel h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.threejs-viewer .tjsv-lighting-panel h3 button {
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 16px;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+}
+.threejs-viewer .tjsv-lighting-panel h3 button:hover { color: white; }
+.threejs-viewer .lighting-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.threejs-viewer .lighting-section label {
+    font-size: 11px;
+    color: #aaa;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.threejs-viewer .lighting-slider-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.threejs-viewer .lighting-slider-row input[type="range"] {
+    flex: 1;
+    accent-color: #0066cc;
+}
+.threejs-viewer .lighting-slider-row .lighting-value {
+    font-family: monospace;
+    font-size: 12px;
+    min-width: 52px;
+    text-align: right;
+}
+.threejs-viewer .lighting-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+.threejs-viewer .lighting-actions .tjsv-lighting-reset {
+    background: #444;
+    border: none;
+    color: white;
+    padding: 6px 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+}
+.threejs-viewer .lighting-actions .tjsv-lighting-reset:hover { background: #555; }
+.threejs-viewer .lighting-hint {
+    font-size: 10px;
+    color: #999;
+    text-align: center;
+}

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -242,6 +242,62 @@ function makeChannelApply(viewer) {
     };
 }
 
+// Default lighting values. Panel ranges: exposure 0.0–3.0, env intensity 0.0–4.0.
+const DEFAULT_TONE_MAPPING_EXPOSURE = 1.0;
+const DEFAULT_ENVIRONMENT_INTENSITY = 2.0;
+const LS_KEY_TONE_MAPPING_EXPOSURE = 'tjsv.toneMappingExposure';
+const LS_KEY_ENVIRONMENT_INTENSITY = 'tjsv.environmentIntensity';
+
+/**
+ * Resolve initial lighting values with precedence:
+ *   URL param (`tone_mapping_exposure`, `environment_intensity`)
+ *   > options (`toneMappingExposure`, `environmentIntensity`)
+ *   > localStorage (`tjsv.toneMappingExposure`, `tjsv.environmentIntensity`)
+ *   > hard defaults.
+ *
+ * The returned object reports whether the effective value was *pinned* by the
+ * URL/options layer — the panel's Reset button restores to that effective
+ * initial value (not to localStorage), so URL-pinned values stick across
+ * reloads even if the user has tweaked the panel on a previous visit.
+ *
+ * @param {Object} options
+ * @param {URLSearchParams} urlParams
+ * @returns {{exposure: number, envIntensity: number, exposurePinned: boolean, envIntensityPinned: boolean}}
+ */
+function resolveLightingDefaults(options, urlParams) {
+    /** @type {(raw: (string|null|number|undefined)) => (number|null)} */
+    const parseFinite = (raw) => {
+        if (raw === null || raw === undefined || raw === '') return null;
+        const n = typeof raw === 'number' ? raw : parseFloat(raw);
+        return Number.isFinite(n) ? n : null;
+    };
+    const urlExp = parseFinite(urlParams.get('tone_mapping_exposure'));
+    const urlEnv = parseFinite(urlParams.get('environment_intensity'));
+    const optExp = parseFinite(options.toneMappingExposure);
+    const optEnv = parseFinite(options.environmentIntensity);
+    let lsExp = null;
+    let lsEnv = null;
+    try {
+        lsExp = parseFinite(localStorage.getItem(LS_KEY_TONE_MAPPING_EXPOSURE));
+        lsEnv = parseFinite(localStorage.getItem(LS_KEY_ENVIRONMENT_INTENSITY));
+    } catch (e) { /* ignore storage errors */ }
+
+    const exposure = urlExp != null ? urlExp
+        : optExp != null ? optExp
+        : lsExp != null ? lsExp
+        : DEFAULT_TONE_MAPPING_EXPOSURE;
+    const envIntensity = urlEnv != null ? urlEnv
+        : optEnv != null ? optEnv
+        : lsEnv != null ? lsEnv
+        : DEFAULT_ENVIRONMENT_INTENSITY;
+    return {
+        exposure,
+        envIntensity,
+        exposurePinned: urlExp != null || optExp != null,
+        envIntensityPinned: urlEnv != null || optEnv != null,
+    };
+}
+
 function applyOpacity(obj, opacity) {
     obj.traverse(child => {
         if (!child.material) return;
@@ -2110,6 +2166,8 @@ export class ThreeJSViewer {
      * @param {boolean} [options.autoConnect=true] - Whether to connect WebSocket immediately
      * @param {string}  [options.htmlTemplate] - HTML template string for UI controls
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
+     * @param {number}  [options.toneMappingExposure] - Override renderer tone-mapping exposure (default 1.0)
+     * @param {number}  [options.environmentIntensity] - Override scene environment intensity (default 2.0)
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -2146,6 +2204,11 @@ export class ThreeJSViewer {
             const port = options.wsPort || parseInt(urlParams.get('ws_port')) || 5666;
             this._wsUrl = `ws://localhost:${port}`;
         }
+
+        // Resolve lighting defaults. Precedence: URL param > options > localStorage > hard default.
+        // URL param is always authoritative (developer's explicit choice) — panel edits go to
+        // localStorage but don't override a URL-provided value on reload.
+        this._lightingDefaults = resolveLightingDefaults(options, urlParams);
 
         // State
         this._objects = new Map();
@@ -2246,7 +2309,15 @@ export class ThreeJSViewer {
         this._btnOrtho = q('.tjsv-btn-ortho');
         this._btnOrbitMode = q('.tjsv-btn-orbit-mode');
         this._btnClip = q('.tjsv-btn-clip');
+        this._btnLighting = q('.tjsv-btn-lighting');
         this._clipPanelEl = q('.tjsv-clipping-panel');
+        this._lightingPanelEl = q('.tjsv-lighting-panel');
+        this._lightingExposureSlider = q('.tjsv-lighting-exposure');
+        this._lightingExposureValue = q('.tjsv-lighting-exposure-value');
+        this._lightingEnvSlider = q('.tjsv-lighting-env');
+        this._lightingEnvValue = q('.tjsv-lighting-env-value');
+        this._lightingResetBtn = q('.tjsv-lighting-reset');
+        this._lightingCloseBtn = q('.tjsv-lighting-close');
         this._clipDistanceSlider = q('.tjsv-clip-distance');
         this._clipDistanceValue = q('.tjsv-clip-distance-value');
         this._clipThicknessSlider = q('.tjsv-clip-thickness');
@@ -2302,7 +2373,7 @@ export class ThreeJSViewer {
         this._renderer.setSize(w, h);
         this._renderer.setPixelRatio(window.devicePixelRatio);
         this._renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this._renderer.toneMappingExposure = 1.5;
+        this._renderer.toneMappingExposure = this._lightingDefaults.exposure;
         this._renderer.localClippingEnabled = true;
         this.el.appendChild(this._renderer.domElement);
 
@@ -2507,7 +2578,7 @@ export class ThreeJSViewer {
                     cubeTexture.needsUpdate = true;
                     const envMap = pmremGenerator.fromCubemap(cubeTexture).texture;
                     scene.environment = envMap;
-                    scene.environmentIntensity = 2.0;
+                    scene.environmentIntensity = this._lightingDefaults.envIntensity;
                     cubeTexture.dispose();
                     pmremGenerator.dispose();
                 }
@@ -2805,6 +2876,66 @@ export class ThreeJSViewer {
         this._clipPanelEl.querySelectorAll('.clip-axis-buttons button').forEach(btn => {
             btn.classList.remove('active');
         });
+    }
+
+    // ========== Lighting Panel ==========
+
+    _toggleLightingPanel() {
+        const visible = this._lightingPanelEl.classList.toggle('visible');
+        this._btnLighting.classList.toggle('active', visible);
+    }
+
+    _applyToneMappingExposure(value) {
+        this._renderer.toneMappingExposure = value;
+    }
+
+    _applyEnvironmentIntensity(value) {
+        this._scene.environmentIntensity = value;
+    }
+
+    _writeLightingLocalStorage(key, value) {
+        try { localStorage.setItem(key, String(value)); } catch (e) { /* ignore quota */ }
+    }
+
+    _resetLightingPanel() {
+        const d = this._lightingDefaults;
+        // Clear localStorage so next reload (without URL params) picks up hard defaults.
+        try { localStorage.removeItem(LS_KEY_TONE_MAPPING_EXPOSURE); } catch (e) { /* ignore */ }
+        try { localStorage.removeItem(LS_KEY_ENVIRONMENT_INTENSITY); } catch (e) { /* ignore */ }
+        this._applyToneMappingExposure(d.exposure);
+        this._applyEnvironmentIntensity(d.envIntensity);
+        this._lightingExposureSlider.value = String(d.exposure);
+        this._lightingExposureValue.textContent = d.exposure.toFixed(2);
+        this._lightingEnvSlider.value = String(d.envIntensity);
+        this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+    }
+
+    _initLightingPanelUI() {
+        const d = this._lightingDefaults;
+        // Seed sliders/readouts with the effective initial values.
+        this._lightingExposureSlider.value = String(d.exposure);
+        this._lightingExposureValue.textContent = d.exposure.toFixed(2);
+        this._lightingEnvSlider.value = String(d.envIntensity);
+        this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+
+        this._btnLighting.addEventListener('click', () => this._toggleLightingPanel());
+        this._lightingCloseBtn.addEventListener('click', () => this._toggleLightingPanel());
+
+        this._lightingExposureSlider.addEventListener('input', () => {
+            const v = parseFloat(this._lightingExposureSlider.value);
+            if (!Number.isFinite(v)) return;
+            this._applyToneMappingExposure(v);
+            this._lightingExposureValue.textContent = v.toFixed(2);
+            this._writeLightingLocalStorage(LS_KEY_TONE_MAPPING_EXPOSURE, v);
+        });
+        this._lightingEnvSlider.addEventListener('input', () => {
+            const v = parseFloat(this._lightingEnvSlider.value);
+            if (!Number.isFinite(v)) return;
+            this._applyEnvironmentIntensity(v);
+            this._lightingEnvValue.textContent = v.toFixed(2);
+            this._writeLightingLocalStorage(LS_KEY_ENVIRONMENT_INTENSITY, v);
+        });
+        this._lightingResetBtn.addEventListener('click', () => this._resetLightingPanel());
     }
 
     // ========== Camera ==========
@@ -3598,6 +3729,9 @@ export class ThreeJSViewer {
         // Clip button
         this._btnClip.addEventListener('click', () => this._toggleClipPanel());
 
+        // Lighting panel
+        this._initLightingPanelUI();
+
         // Clip axis buttons
         this._clipPanelEl.querySelectorAll('.clip-axis-buttons button').forEach(btn => {
             btn.addEventListener('click', () => this._setClipAxis(btn.dataset.axis));
@@ -3708,6 +3842,10 @@ export class ThreeJSViewer {
             }
             if (e.code === 'KeyC' && !e.ctrlKey && !e.metaKey) {
                 this._toggleClipPanel();
+                return;
+            }
+            if (e.code === 'KeyE' && !e.ctrlKey && !e.metaKey) {
+                this._toggleLightingPanel();
                 return;
             }
             if (e.code === 'KeyM' && !e.ctrlKey && !e.metaKey) {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -269,16 +269,19 @@ function toneMappingModes() {
 const TONE_MAPPING_MODE_NAMES = ['none', 'linear', 'reinhard', 'cineon', 'aces', 'agx', 'neutral'];
 
 /**
- * Resolve initial lighting values with precedence:
- *   URL param (`tone_mapping`, `tone_mapping_exposure`, `environment_intensity`, `ambient_intensity`)
- *   > options (`toneMapping`, `toneMappingExposure`, `environmentIntensity`, `ambientIntensity`)
- *   > localStorage (`tjsv.toneMapping`, `tjsv.toneMappingExposure`, `tjsv.environmentIntensity`, `tjsv.ambientIntensity`)
- *   > hard defaults.
+ * Resolve lighting values with two layered views:
  *
- * The returned object reports whether each effective value was *pinned* by
- * the URL/options layer — the panel's Reset button restores to that
- * effective initial value (not to localStorage), so URL-pinned values stick
- * across reloads even if the user has tweaked the panel on a previous visit.
+ *   `reset`  — the baseline the panel's Reset button restores to. Uses
+ *              URL param > options > hard defaults (localStorage is ignored
+ *              here, because "Reset" means "go back to the developer default
+ *              for this page load", not "re-apply the last session's tweak").
+ *   top-level — the effective initial values applied at startup and used
+ *              to seed the panel UI. Uses URL param > options > localStorage
+ *              > hard defaults.
+ *
+ * URL-pinned / option-pinned values end up identical in both views, so
+ * reloading a URL with `tone_mapping_exposure=2.3` sticks across reloads
+ * even if the user previously tweaked the panel.
  *
  * Invalid tone-mapping strings (not one of the seven known modes) and
  * non-finite numeric values silently fall through to the next level — we
@@ -291,10 +294,12 @@ const TONE_MAPPING_MODE_NAMES = ['none', 'linear', 'reinhard', 'cineon', 'aces',
  *     envIntensity: number,
  *     ambientIntensity: number,
  *     toneMapping: string,
- *     exposurePinned: boolean,
- *     envIntensityPinned: boolean,
- *     ambientIntensityPinned: boolean,
- *     toneMappingPinned: boolean,
+ *     reset: {
+ *         exposure: number,
+ *         envIntensity: number,
+ *         ambientIntensity: number,
+ *         toneMapping: string,
+ *     },
  * }}
  */
 function resolveLightingDefaults(options, urlParams) {
@@ -329,6 +334,22 @@ function resolveLightingDefaults(options, urlParams) {
         lsTm = parseToneMapping(localStorage.getItem(LS_KEY_TONE_MAPPING));
     } catch (e) { /* ignore storage errors */ }
 
+    // Reset baseline: URL > options > hard defaults (no localStorage).
+    const resetExposure = urlExp != null ? urlExp
+        : optExp != null ? optExp
+        : DEFAULT_TONE_MAPPING_EXPOSURE;
+    const resetEnvIntensity = urlEnv != null ? urlEnv
+        : optEnv != null ? optEnv
+        : DEFAULT_ENVIRONMENT_INTENSITY;
+    const resetAmbientIntensity = urlAmb != null ? urlAmb
+        : optAmb != null ? optAmb
+        : DEFAULT_AMBIENT_INTENSITY;
+    const resetToneMapping = urlTm != null ? urlTm
+        : optTm != null ? optTm
+        : DEFAULT_TONE_MAPPING;
+
+    // Effective initial: localStorage overlays the reset baseline, but only
+    // when URL/options haven't already pinned the value.
     const exposure = urlExp != null ? urlExp
         : optExp != null ? optExp
         : lsExp != null ? lsExp
@@ -350,10 +371,12 @@ function resolveLightingDefaults(options, urlParams) {
         envIntensity,
         ambientIntensity,
         toneMapping,
-        exposurePinned: urlExp != null || optExp != null,
-        envIntensityPinned: urlEnv != null || optEnv != null,
-        ambientIntensityPinned: urlAmb != null || optAmb != null,
-        toneMappingPinned: urlTm != null || optTm != null,
+        reset: {
+            exposure: resetExposure,
+            envIntensity: resetEnvIntensity,
+            ambientIntensity: resetAmbientIntensity,
+            toneMapping: resetToneMapping,
+        },
     };
 }
 
@@ -3067,8 +3090,12 @@ export class ThreeJSViewer {
     }
 
     _resetLightingPanel() {
-        const d = this._lightingDefaults;
-        // Clear localStorage so next reload (without URL params) picks up hard defaults.
+        // Reset target: the pre-localStorage baseline (URL > options > hard
+        // defaults). Using _lightingDefaults directly would be a no-op when
+        // the page was seeded from localStorage, because localStorage already
+        // participated in that resolution — Reset is meant to *escape* the
+        // user's persisted tweaks, not re-apply them.
+        const d = this._lightingDefaults.reset;
         try { localStorage.removeItem(LS_KEY_TONE_MAPPING_EXPOSURE); } catch (e) { /* ignore */ }
         try { localStorage.removeItem(LS_KEY_ENVIRONMENT_INTENSITY); } catch (e) { /* ignore */ }
         try { localStorage.removeItem(LS_KEY_AMBIENT_INTENSITY); } catch (e) { /* ignore */ }

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -242,27 +242,60 @@ function makeChannelApply(viewer) {
     };
 }
 
-// Default lighting values. Panel ranges: exposure 0.0–3.0, env intensity 0.0–4.0.
+// Default lighting values. Panel ranges: exposure 0.0–3.0, env intensity 0.0–4.0, ambient 0.0–3.0.
 const DEFAULT_TONE_MAPPING_EXPOSURE = 1.0;
 const DEFAULT_ENVIRONMENT_INTENSITY = 2.0;
+const DEFAULT_AMBIENT_INTENSITY = 1.5;
+const DEFAULT_TONE_MAPPING = 'aces';
 const LS_KEY_TONE_MAPPING_EXPOSURE = 'tjsv.toneMappingExposure';
 const LS_KEY_ENVIRONMENT_INTENSITY = 'tjsv.environmentIntensity';
+const LS_KEY_AMBIENT_INTENSITY = 'tjsv.ambientIntensity';
+const LS_KEY_TONE_MAPPING = 'tjsv.toneMapping';
+
+// Tone-mapping mode name -> THREE.* constant. Resolved lazily so THREE only
+// needs to be loaded when the viewer actually instantiates.
+/** @returns {Record<string, number>} */
+function toneMappingModes() {
+    return {
+        none: THREE.NoToneMapping,
+        linear: THREE.LinearToneMapping,
+        reinhard: THREE.ReinhardToneMapping,
+        cineon: THREE.CineonToneMapping,
+        aces: THREE.ACESFilmicToneMapping,
+        agx: THREE.AgXToneMapping,
+        neutral: THREE.NeutralToneMapping,
+    };
+}
+const TONE_MAPPING_MODE_NAMES = ['none', 'linear', 'reinhard', 'cineon', 'aces', 'agx', 'neutral'];
 
 /**
  * Resolve initial lighting values with precedence:
- *   URL param (`tone_mapping_exposure`, `environment_intensity`)
- *   > options (`toneMappingExposure`, `environmentIntensity`)
- *   > localStorage (`tjsv.toneMappingExposure`, `tjsv.environmentIntensity`)
+ *   URL param (`tone_mapping`, `tone_mapping_exposure`, `environment_intensity`, `ambient_intensity`)
+ *   > options (`toneMapping`, `toneMappingExposure`, `environmentIntensity`, `ambientIntensity`)
+ *   > localStorage (`tjsv.toneMapping`, `tjsv.toneMappingExposure`, `tjsv.environmentIntensity`, `tjsv.ambientIntensity`)
  *   > hard defaults.
  *
- * The returned object reports whether the effective value was *pinned* by the
- * URL/options layer — the panel's Reset button restores to that effective
- * initial value (not to localStorage), so URL-pinned values stick across
- * reloads even if the user has tweaked the panel on a previous visit.
+ * The returned object reports whether each effective value was *pinned* by
+ * the URL/options layer — the panel's Reset button restores to that
+ * effective initial value (not to localStorage), so URL-pinned values stick
+ * across reloads even if the user has tweaked the panel on a previous visit.
+ *
+ * Invalid tone-mapping strings (not one of the seven known modes) and
+ * non-finite numeric values silently fall through to the next level — we
+ * never throw in the browser here; Python already validates its kwargs.
  *
  * @param {Object} options
  * @param {URLSearchParams} urlParams
- * @returns {{exposure: number, envIntensity: number, exposurePinned: boolean, envIntensityPinned: boolean}}
+ * @returns {{
+ *     exposure: number,
+ *     envIntensity: number,
+ *     ambientIntensity: number,
+ *     toneMapping: string,
+ *     exposurePinned: boolean,
+ *     envIntensityPinned: boolean,
+ *     ambientIntensityPinned: boolean,
+ *     toneMappingPinned: boolean,
+ * }}
  */
 function resolveLightingDefaults(options, urlParams) {
     /** @type {(raw: (string|null|number|undefined)) => (number|null)} */
@@ -271,15 +304,29 @@ function resolveLightingDefaults(options, urlParams) {
         const n = typeof raw === 'number' ? raw : parseFloat(raw);
         return Number.isFinite(n) ? n : null;
     };
+    /** @type {(raw: (string|null|undefined)) => (string|null)} */
+    const parseToneMapping = (raw) => {
+        if (raw === null || raw === undefined || raw === '') return null;
+        const s = String(raw).toLowerCase();
+        return TONE_MAPPING_MODE_NAMES.includes(s) ? s : null;
+    };
     const urlExp = parseFinite(urlParams.get('tone_mapping_exposure'));
     const urlEnv = parseFinite(urlParams.get('environment_intensity'));
+    const urlAmb = parseFinite(urlParams.get('ambient_intensity'));
+    const urlTm = parseToneMapping(urlParams.get('tone_mapping'));
     const optExp = parseFinite(options.toneMappingExposure);
     const optEnv = parseFinite(options.environmentIntensity);
+    const optAmb = parseFinite(options.ambientIntensity);
+    const optTm = parseToneMapping(options.toneMapping);
     let lsExp = null;
     let lsEnv = null;
+    let lsAmb = null;
+    let lsTm = null;
     try {
         lsExp = parseFinite(localStorage.getItem(LS_KEY_TONE_MAPPING_EXPOSURE));
         lsEnv = parseFinite(localStorage.getItem(LS_KEY_ENVIRONMENT_INTENSITY));
+        lsAmb = parseFinite(localStorage.getItem(LS_KEY_AMBIENT_INTENSITY));
+        lsTm = parseToneMapping(localStorage.getItem(LS_KEY_TONE_MAPPING));
     } catch (e) { /* ignore storage errors */ }
 
     const exposure = urlExp != null ? urlExp
@@ -290,11 +337,23 @@ function resolveLightingDefaults(options, urlParams) {
         : optEnv != null ? optEnv
         : lsEnv != null ? lsEnv
         : DEFAULT_ENVIRONMENT_INTENSITY;
+    const ambientIntensity = urlAmb != null ? urlAmb
+        : optAmb != null ? optAmb
+        : lsAmb != null ? lsAmb
+        : DEFAULT_AMBIENT_INTENSITY;
+    const toneMapping = urlTm != null ? urlTm
+        : optTm != null ? optTm
+        : lsTm != null ? lsTm
+        : DEFAULT_TONE_MAPPING;
     return {
         exposure,
         envIntensity,
+        ambientIntensity,
+        toneMapping,
         exposurePinned: urlExp != null || optExp != null,
         envIntensityPinned: urlEnv != null || optEnv != null,
+        ambientIntensityPinned: urlAmb != null || optAmb != null,
+        toneMappingPinned: urlTm != null || optTm != null,
     };
 }
 
@@ -2168,6 +2227,8 @@ export class ThreeJSViewer {
      * @param {Object}  [options.cubemapData]  - {px,nx,py,ny,pz,nz} base64 JPEG strings
      * @param {number}  [options.toneMappingExposure] - Override renderer tone-mapping exposure (default 1.0)
      * @param {number}  [options.environmentIntensity] - Override scene environment intensity (default 2.0)
+     * @param {number}  [options.ambientIntensity] - Override ambient-light intensity (default 1.5)
+     * @param {string}  [options.toneMapping] - Tone-mapping mode: one of none/linear/reinhard/cineon/aces/agx/neutral (default "aces")
      */
     constructor(container, options = {}) {
         if (!container) throw new Error('ThreeJSViewer: container element is required');
@@ -2316,6 +2377,9 @@ export class ThreeJSViewer {
         this._lightingExposureValue = q('.tjsv-lighting-exposure-value');
         this._lightingEnvSlider = q('.tjsv-lighting-env');
         this._lightingEnvValue = q('.tjsv-lighting-env-value');
+        this._lightingAmbientSlider = q('.tjsv-lighting-ambient');
+        this._lightingAmbientValue = q('.tjsv-lighting-ambient-value');
+        this._lightingToneMappingSelect = q('.tjsv-lighting-tone-mapping');
         this._lightingResetBtn = q('.tjsv-lighting-reset');
         this._lightingCloseBtn = q('.tjsv-lighting-close');
         this._clipDistanceSlider = q('.tjsv-clip-distance');
@@ -2372,7 +2436,9 @@ export class ThreeJSViewer {
         this._renderer = new THREE.WebGLRenderer({ antialias: true });
         this._renderer.setSize(w, h);
         this._renderer.setPixelRatio(window.devicePixelRatio);
-        this._renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this._renderer.toneMapping = /** @type {THREE.ToneMapping} */ (
+            toneMappingModes()[this._lightingDefaults.toneMapping]
+        );
         this._renderer.toneMappingExposure = this._lightingDefaults.exposure;
         this._renderer.localClippingEnabled = true;
         this.el.appendChild(this._renderer.domElement);
@@ -2520,9 +2586,9 @@ export class ThreeJSViewer {
             this.frameObject(target);
         });
 
-        // Lighting
-        const ambientLight = new THREE.AmbientLight(0xffffff, 1.5);
-        this._scene.add(ambientLight);
+        // Lighting — kept as an instance ref so the Lighting panel can tune intensity at runtime.
+        this._ambientLight = new THREE.AmbientLight(0xffffff, this._lightingDefaults.ambientIntensity);
+        this._scene.add(this._ambientLight);
 
         // Grid helper on XY plane (Z-up) — hidden by default
         this._gridHelper = new THREE.GridHelper(10, 10);
@@ -2893,6 +2959,38 @@ export class ThreeJSViewer {
         this._scene.environmentIntensity = value;
     }
 
+    _applyAmbientIntensity(value) {
+        if (this._ambientLight) this._ambientLight.intensity = value;
+    }
+
+    /**
+     * Set the renderer tone-mapping mode and flush every material's shader.
+     *
+     * Three.js bakes `renderer.toneMapping` into each material's shader at
+     * compile time, so changing the renderer value alone has no visible
+     * effect on already-compiled materials. Setting `material.needsUpdate =
+     * true` marks the program for recompilation on the next draw, which is
+     * the documented invalidation path in three.js 0.183.
+     *
+     * @param {string} mode - one of the keys in toneMappingModes().
+     */
+    _applyToneMapping(mode) {
+        const modes = toneMappingModes();
+        if (!(mode in modes)) return;
+        this._renderer.toneMapping = /** @type {THREE.ToneMapping} */ (modes[mode]);
+        // Flush shaders on every material currently in the scene so they
+        // recompile against the new tone-mapping constant.
+        this._scene.traverse((obj) => {
+            const mat = /** @type {any} */ (obj).material;
+            if (!mat) return;
+            if (Array.isArray(mat)) {
+                for (const m of mat) { if (m) m.needsUpdate = true; }
+            } else {
+                mat.needsUpdate = true;
+            }
+        });
+    }
+
     _writeLightingLocalStorage(key, value) {
         try { localStorage.setItem(key, String(value)); } catch (e) { /* ignore quota */ }
     }
@@ -2902,25 +3000,41 @@ export class ThreeJSViewer {
         // Clear localStorage so next reload (without URL params) picks up hard defaults.
         try { localStorage.removeItem(LS_KEY_TONE_MAPPING_EXPOSURE); } catch (e) { /* ignore */ }
         try { localStorage.removeItem(LS_KEY_ENVIRONMENT_INTENSITY); } catch (e) { /* ignore */ }
+        try { localStorage.removeItem(LS_KEY_AMBIENT_INTENSITY); } catch (e) { /* ignore */ }
+        try { localStorage.removeItem(LS_KEY_TONE_MAPPING); } catch (e) { /* ignore */ }
+        this._applyToneMapping(d.toneMapping);
         this._applyToneMappingExposure(d.exposure);
         this._applyEnvironmentIntensity(d.envIntensity);
+        this._applyAmbientIntensity(d.ambientIntensity);
+        this._lightingToneMappingSelect.value = d.toneMapping;
         this._lightingExposureSlider.value = String(d.exposure);
         this._lightingExposureValue.textContent = d.exposure.toFixed(2);
         this._lightingEnvSlider.value = String(d.envIntensity);
         this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+        this._lightingAmbientSlider.value = String(d.ambientIntensity);
+        this._lightingAmbientValue.textContent = d.ambientIntensity.toFixed(2);
     }
 
     _initLightingPanelUI() {
         const d = this._lightingDefaults;
         // Seed sliders/readouts with the effective initial values.
+        this._lightingToneMappingSelect.value = d.toneMapping;
         this._lightingExposureSlider.value = String(d.exposure);
         this._lightingExposureValue.textContent = d.exposure.toFixed(2);
         this._lightingEnvSlider.value = String(d.envIntensity);
         this._lightingEnvValue.textContent = d.envIntensity.toFixed(2);
+        this._lightingAmbientSlider.value = String(d.ambientIntensity);
+        this._lightingAmbientValue.textContent = d.ambientIntensity.toFixed(2);
 
         this._btnLighting.addEventListener('click', () => this._toggleLightingPanel());
         this._lightingCloseBtn.addEventListener('click', () => this._toggleLightingPanel());
 
+        this._lightingToneMappingSelect.addEventListener('change', () => {
+            const mode = this._lightingToneMappingSelect.value;
+            if (!TONE_MAPPING_MODE_NAMES.includes(mode)) return;
+            this._applyToneMapping(mode);
+            this._writeLightingLocalStorage(LS_KEY_TONE_MAPPING, mode);
+        });
         this._lightingExposureSlider.addEventListener('input', () => {
             const v = parseFloat(this._lightingExposureSlider.value);
             if (!Number.isFinite(v)) return;
@@ -2934,6 +3048,13 @@ export class ThreeJSViewer {
             this._applyEnvironmentIntensity(v);
             this._lightingEnvValue.textContent = v.toFixed(2);
             this._writeLightingLocalStorage(LS_KEY_ENVIRONMENT_INTENSITY, v);
+        });
+        this._lightingAmbientSlider.addEventListener('input', () => {
+            const v = parseFloat(this._lightingAmbientSlider.value);
+            if (!Number.isFinite(v)) return;
+            this._applyAmbientIntensity(v);
+            this._lightingAmbientValue.textContent = v.toFixed(2);
+            this._writeLightingLocalStorage(LS_KEY_AMBIENT_INTENSITY, v);
         });
         this._lightingResetBtn.addEventListener('click', () => this._resetLightingPanel());
     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,9 @@
 """Tests for ViewerClient."""
 
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
 
 from threejs_viewer import ViewerClient
 
@@ -27,3 +30,61 @@ def test_viewer_path():
     assert isinstance(path, Path)
     assert path.exists()
     assert path.name == "viewer.html"
+
+
+def _params(url: str) -> dict[str, list[str]]:
+    return parse_qs(urlparse(url).query)
+
+
+def test_viewer_url_default_has_only_ws_port():
+    """No lighting kwargs → only ws_port in the query string."""
+    client = ViewerClient(port=1234)
+    params = _params(client.viewer_url)
+    assert params == {"ws_port": ["1234"]}
+
+
+def test_viewer_url_with_tone_mapping_exposure_zero():
+    """0.0 must still be emitted (falsy float slipped through the old check)."""
+    client = ViewerClient(tone_mapping_exposure=0.0)
+    params = _params(client.viewer_url)
+    assert params["tone_mapping_exposure"] == ["0.0"]
+
+
+def test_viewer_url_with_all_lighting_overrides():
+    """All four lighting kwargs round-trip through the URL."""
+    client = ViewerClient(
+        tone_mapping="AgX",  # upper/mixed case accepted, normalized to lowercase
+        tone_mapping_exposure=2.3,
+        environment_intensity=0.5,
+        ambient_intensity=0.7,
+    )
+    params = _params(client.viewer_url)
+    assert params["ws_port"] == ["5666"]
+    assert params["tone_mapping"] == ["agx"]
+    assert params["tone_mapping_exposure"] == ["2.3"]
+    assert params["environment_intensity"] == ["0.5"]
+    assert params["ambient_intensity"] == ["0.7"]
+
+
+def test_viewer_url_partial_overrides():
+    """Only the kwargs the caller supplied appear in the URL."""
+    client = ViewerClient(environment_intensity=1.25)
+    params = _params(client.viewer_url)
+    assert set(params) == {"ws_port", "environment_intensity"}
+    assert params["environment_intensity"] == ["1.25"]
+
+
+def test_viewer_client_rejects_invalid_tone_mapping():
+    with pytest.raises(ValueError, match="tone_mapping must be one of"):
+        ViewerClient(tone_mapping="bogus")
+
+
+@pytest.mark.parametrize(
+    "kwarg",
+    ["tone_mapping_exposure", "environment_intensity", "ambient_intensity"],
+)
+def test_viewer_client_rejects_non_finite_floats(kwarg):
+    with pytest.raises(ValueError, match="must be a finite number"):
+        ViewerClient(**{kwarg: float("nan")})
+    with pytest.raises(ValueError, match="must be a finite number"):
+        ViewerClient(**{kwarg: float("inf")})


### PR DESCRIPTION
## Summary

- **Default exposure lowered 1.5 → 1.0** in the viewer's default tone-mapping pipeline. Fixes the red-bleaching / highlight clipping observed on saturated toolpath colors.
- **Runtime lighting panel** toggled by `E` (or toolbar button `☼ E`). Four controls, live-applied to the scene, values persist in localStorage under the `tjsv.` namespace, Reset button restores the effective initial values and clears the panel's localStorage keys:
  - **Tone mapping** (`<select>`): one of `none`, `linear`, `reinhard`, `cineon`, `aces` (default), `agx`, `neutral`. Lets us compare AgX / Neutral against ACES Filmic on saturated colors at runtime. Changing the mode flushes every material's shader (`material.needsUpdate = true`) because three.js bakes the tone-mapping constant into compiled programs.
  - **Tone mapping exposure** (slider 0.0–3.0, step 0.05) → `renderer.toneMappingExposure`.
  - **Environment intensity** (slider 0.0–4.0, step 0.05) → `scene.environmentIntensity`.
  - **Ambient intensity** (slider 0.0–3.0, step 0.05) → `ambientLight.intensity` (the existing `AmbientLight` is now stored on `this._ambientLight` so the panel can reach it).
- **Lighting overrides plumbed from Python → browser**. `ViewerClient.__init__` accepts four new kwargs: `tone_mapping: Optional[str]` (validated case-insensitively against the seven modes, raises `ValueError` otherwise), `tone_mapping_exposure: Optional[float]`, `environment_intensity: Optional[float]`, `ambient_intensity: Optional[float]`. When set, they're appended to `viewer_url` as snake_case query params (`tone_mapping`, `tone_mapping_exposure`, `environment_intensity`, `ambient_intensity`) and consumed by the viewer constructor.

Precedence for every initial lighting value: **URL param > `ThreeJSViewer` option > localStorage > hard default.** A URL-pinned value always wins on reload, even if the user tweaked the panel on a previous visit. Invalid tone-mapping strings from URL or localStorage fall through silently in the browser; invalid strings from Python raise `ValueError` at construction with the allowed list.

Panel layout (top to bottom): Tone mapping, Exposure, Environment intensity, Ambient intensity, Reset.

## Test plan

- [ ] `uv run pytest -q` → 122 passed (+36 skipped browser tests)
- [ ] `uv run ruff check . && uv run ruff format --check .` → clean
- [ ] `npx tsc --noEmit -p jsconfig.json` → clean (no JS type errors)
- [ ] Manual: launch `uv run python examples/01_primitives.py`, press `E`, panel opens bottom-right and doesn't overlap the clipping panel
- [ ] Manual: move the exposure slider → scene re-renders live, readout updates, value persists across page reload (without any URL kwargs)
- [ ] Manual: change the **tone-mapping dropdown** from ACES → AgX → Neutral → Cineon → ACES on a scene with saturated reds/oranges; each swap should visibly change the look on the next frame (verify material shaders are actually recompiling)
- [ ] Manual: drag the **ambient intensity** slider 0 → 3 → 1.5; the scene brightens/darkens live, shadows get softer as ambient goes up, readout updates, value persists across reload
- [ ] Manual: press Reset with non-default values in all four controls → all four snap back to defaults (aces / 1.0 / 2.0 / 1.5) and the four `tjsv.*` localStorage keys are cleared
- [ ] Manual: `ViewerClient(tone_mapping="agx", tone_mapping_exposure=2.3, environment_intensity=0.5, ambient_intensity=0.7)` → URL contains all four params and the panel opens with those values even if localStorage had something else
- [ ] Manual: `ViewerClient(tone_mapping="bogus")` → raises `ValueError` listing the seven allowed modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)