### PR TITLE
Fix lookat camera tracking no-op after ViewerControls migration

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -5191,6 +5191,9 @@ class ThreeJSViewer {
             }
         } else if (this._trackMode === 'lookat') {
             this._controls.target.copy(targetPos);
+            // ViewerControls never calls camera.lookAt (would break click-to-pivot),
+            // so re-orient the camera explicitly here to actually track the target.
+            this._camera.lookAt(targetPos);
         }
 
         this._trackLastPos.copy(targetPos);

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -4168,6 +4168,9 @@ export class ThreeJSViewer {
             }
         } else if (this._trackMode === 'lookat') {
             this._controls.target.copy(targetPos);
+            // ViewerControls never calls camera.lookAt (would break click-to-pivot),
+            // so re-orient the camera explicitly here to actually track the target.
+            this._camera.lookAt(targetPos);
         }
 
         this._trackLastPos.copy(targetPos);


### PR DESCRIPTION
## Summary
- The `lookat` track mode in `_applyCameraTracking` was only moving `_controls.target` to the tracked object each frame but never re-orienting the camera — so the view stayed pointed wherever it was before.
- Root cause: `ViewerControls` (introduced in 8c9e10d) deliberately never calls `camera.lookAt` inside `update()` to preserve its click-to-pivot guarantee. Stock `OrbitControls` used to do the re-orient; the custom controls don't.
- Fix: explicitly call `this._camera.lookAt(targetPos)` in the `lookat` branch. Matches the precedent already in place in `CameraController` at `viewer.js:2325` for camera-swap framing.
- `follow` mode is unaffected — it translates camera and target by the same delta, preserving the view offset without needing any re-orient.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `npx tsc --noEmit -p jsconfig.json`
- [x] `uv run pytest` (182 passed)
- [x] Manual verification by author: lookat tracking now follows a moving object in animation playback
- [ ] (optional follow-up) add a Playwright test that plays an animation with `camera_lookat` and asserts the camera's forward vector points at the tracked object

🤖 Generated with [Claude Code](https://claude.com/claude-code)