### PR TITLE
Gizmo hover feedback + Home button, predictable resetView

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -458,6 +458,42 @@
             color: #999;
             text-align: center;
         }
+
+        /* Home button — centered inside the 128×128 ViewHelper area, shifts up
+           with the animation toolbar via --tjsv-anim-lift (set from JS). */
+        .threejs-viewer .tjsv-view-home {
+            position: absolute;
+            right: 46px;
+            bottom: calc(46px + var(--tjsv-anim-lift, 0px));
+            width: 36px;
+            height: 36px;
+            padding: 0;
+            border-radius: 50%;
+            background: rgba(30, 30, 30, 0.72);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            color: #ddd;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            user-select: none;
+            opacity: 0.75;
+            transition: background 0.15s, color 0.15s, opacity 0.15s, transform 0.15s;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+            z-index: 2;
+        }
+        .threejs-viewer .tjsv-view-home:hover {
+            background: rgba(60, 60, 60, 0.95);
+            color: white;
+            opacity: 1;
+            transform: scale(1.06);
+        }
+        .threejs-viewer .tjsv-view-home:active {
+            transform: scale(0.96);
+        }
+        .threejs-viewer .tjsv-view-home:focus {
+            outline: none;
+        }
     </style>
     <script type="importmap">
     {
@@ -605,6 +641,14 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
     </div>
     <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
 </div>
+
+<button class="tjsv-view-home" title="Reset view (F)" tabindex="-1">
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
+        <path d="M3 11.5 L12 3 L21 11.5 M5 10 V20 H10 V14 H14 V20 H19 V10"
+              fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linejoin="round" stroke-linecap="round"/>
+    </svg>
+</button>
 `;
 
 // @ts-check
@@ -3262,8 +3306,10 @@ class CameraController {
         v._controls.target.copy(tgt);
         v._controls.update();
         v._clipGizmo.camera = v._camera;
+        v._setGizmoHoverSprite(null);
         v._viewHelper = new ViewHelper(v._camera, v._renderer.domElement);
         v._viewHelper.center = v._controls.target;
+        v._configureViewHelper(v._viewHelper);
         v._btnOrtho.textContent = '\u2B1A O';
         v._btnOrtho.classList.toggle('active', v._isOrtho);
     }
@@ -3809,6 +3855,7 @@ class ThreeJSViewer {
         this._clipThicknessSection = q('.tjsv-clip-thickness-section');
         this._clipClose = q('.tjsv-clip-close');
         this._animControlsEl = q('.tjsv-animation-controls');
+        this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
         this._timelineMarkersEl = q('.tjsv-timeline-markers');
         this._currentTimeEl = q('.tjsv-current-time');
@@ -3968,12 +4015,53 @@ class ThreeJSViewer {
                 if (md) md.ringColors = redRc;
             }
         };
-        // ViewHelper
+        // ViewHelper — axis sprites are enlarged for easier hit-testing, and a
+        // custom hover raycast lights up the sprite under the cursor so users
+        // can see when a click will actually land. Pointerdown inside the gizmo
+        // rect is suppressed at capture to prevent click-to-pivot from firing
+        // on near-misses.
+        this._gizmoDim = 128;
+        this._gizmoBaseScale = 1.4;
+        this._gizmoHoverScale = 1.75;
+        this._gizmoHoverRaycaster = new THREE.Raycaster();
+        this._gizmoHoverOrthoCam = new THREE.OrthographicCamera(-2, 2, 2, -2, 0, 4);
+        this._gizmoHoverOrthoCam.position.set(0, 0, 2);
+        this._gizmoHoverOrthoCam.updateMatrixWorld();
+        this._gizmoHovered = null;
         this._viewHelper = new ViewHelper(this._camera, this._renderer.domElement);
         this._viewHelper.center = this._controls.target;
+        this._configureViewHelper(this._viewHelper);
+
+        // Suppress click-to-pivot when the pointer is inside the gizmo rect.
+        // Runs at capture so it fires before ViewerControls' pointerdown listener.
+        this._renderer.domElement.addEventListener('pointerdown', (e) => {
+            if (this._gizmoHitTest(e).insideRect) {
+                e.stopImmediatePropagation();
+            }
+        }, true);
+
+        // Hover feedback: highlight the sprite under the cursor + pointer cursor.
+        this._renderer.domElement.addEventListener('pointermove', (e) => {
+            if (this._viewHelper.animating) return;
+            const { hit } = this._gizmoHitTest(e);
+            this._setGizmoHoverSprite(hit);
+            this._renderer.domElement.style.cursor = hit ? 'pointer' : '';
+        });
+        this._renderer.domElement.addEventListener('pointerleave', () => {
+            this._setGizmoHoverSprite(null);
+            this._renderer.domElement.style.cursor = '';
+        });
+
         this._renderer.domElement.addEventListener('click', (e) => {
-            if (this._viewHelper.handleClick(e)) {
+            if (this._viewHelper.animating) return;
+            // ViewHelper.handleClick assumes the gizmo sits at bottom:0, but we
+            // lift it above the animation toolbar when visible — shim clientY
+            // so handleClick's raycast maps to the rendered location.
+            const liftCss = this._gizmoLiftCss();
+            const shim = { clientX: e.clientX, clientY: e.clientY + liftCss };
+            if (this._viewHelper.handleClick(/** @type {any} */ (shim))) {
                 this._controls.target.copy(this._viewHelper.center);
+                this._setGizmoHoverSprite(null);
             }
         });
         // Double-click an object to frame it; double-click empty space to reset.
@@ -4864,6 +4952,9 @@ class ThreeJSViewer {
         }
 
         this._animControlsEl.classList.add('visible');
+        // Reading offsetHeight forces layout so --tjsv-anim-lift reflects the
+        // now-visible toolbar; CSS uses it to shift the Home button up.
+        this.el.style.setProperty('--tjsv-anim-lift', `${this._animControlsEl.offsetHeight}px`);
         this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
@@ -4930,6 +5021,7 @@ class ThreeJSViewer {
         this._animationPlaying = false;
         this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
+        this.el.style.setProperty('--tjsv-anim-lift', '0px');
         this._trackMode = 'off';
         this._trackTargetId = null;
         this._trackHasLastPos = false;
@@ -5389,6 +5481,14 @@ class ThreeJSViewer {
         this._btnTrack.addEventListener('click', () => this._cycleTrackMode());
         this.el.querySelector('.tjsv-btn-slower').addEventListener('click', () => this._stepSpeed(-1));
         this.el.querySelector('.tjsv-btn-faster').addEventListener('click', () => this._stepSpeed(1));
+
+        // Home button: sits centered in the ViewHelper area and resets the view.
+        if (this._viewHomeBtn) {
+            this._viewHomeBtn.addEventListener('click', () => {
+                this.resetView();
+                this._viewHomeBtn.blur();
+            });
+        }
 
         // Timeline scrubbing
         this._timelineContainer.addEventListener('mousedown', /** @param {MouseEvent} e */ (e) => {
@@ -6658,18 +6758,118 @@ class ThreeJSViewer {
         this._fitCameraToBox(bbox, 1.5);
     }
 
-    resetView() {
-        // Hail-mary: reset camera up to world-Z, point at origin, then frame
-        // everything. Recovers from degenerate / inverted / lost states.
-        this._camera.up.set(0, 0, 1);
-        const dir = this._camera.position.clone().sub(this._controls.target);
-        if (dir.lengthSq() < 1e-10) {
-            this._camera.position.set(5, -5, 5);
+    // ========== ViewHelper (corner gizmo) ==========
+
+    /**
+     * Enlarge the ViewHelper's axis sprites so they have a bigger hit target
+     * and a more visible cue. Baseline opacity is captured for the hover
+     * restore. Called once per ViewHelper instance — the helper is re-created
+     * on every perspective/ortho swap.
+     * @param {any} helper
+     */
+    _configureViewHelper(helper) {
+        const sprites = [];
+        for (const child of helper.children) {
+            if (!child.userData || !child.userData.type) continue;
+            child.scale.setScalar(this._gizmoBaseScale);
+            child.userData.baseOpacity = child.material.opacity;
+            sprites.push(child);
         }
-        this._controls.target.set(0, 0, 0);
-        this._camera.lookAt(0, 0, 0);
+        helper.userData.interactiveSprites = sprites;
+    }
+
+    /**
+     * CSS-pixel lift applied to the gizmo when the animation toolbar is
+     * visible — matches the render-time shim in the main loop.
+     */
+    _gizmoLiftCss() {
+        const el = this._animControlsEl;
+        return (el && el.classList.contains('visible')) ? el.offsetHeight : 0;
+    }
+
+    /**
+     * Hit-test a pointer event against the ViewHelper's axis sprites. Returns
+     * whether the pointer is inside the 128×128 gizmo rect at all, plus the
+     * hovered sprite (null if no sprite under cursor).
+     * @param {PointerEvent | MouseEvent} e
+     * @returns {{ insideRect: boolean, hit: any }}
+     */
+    _gizmoHitTest(e) {
+        const dom = this._renderer.domElement;
+        const rect = dom.getBoundingClientRect();
+        const dim = this._gizmoDim;
+        const liftCss = this._gizmoLiftCss();
+        const offsetX = rect.left + dom.offsetWidth - dim;
+        const offsetY = rect.top + dom.offsetHeight - dim - liftCss;
+        const insideRect =
+            e.clientX >= offsetX && e.clientX <= offsetX + dim &&
+            e.clientY >= offsetY && e.clientY <= offsetY + dim;
+        if (!insideRect) return { insideRect: false, hit: null };
+        const sprites = this._viewHelper.userData.interactiveSprites;
+        if (!sprites || sprites.length === 0) return { insideRect: true, hit: null };
+        const ndcX = ((e.clientX - offsetX) / dim) * 2 - 1;
+        const ndcY = -((e.clientY - offsetY) / dim) * 2 + 1;
+        this._gizmoHoverRaycaster.setFromCamera(
+            new THREE.Vector2(ndcX, ndcY),
+            this._gizmoHoverOrthoCam,
+        );
+        const hits = this._gizmoHoverRaycaster.intersectObjects(sprites, false);
+        return { insideRect: true, hit: hits.length ? hits[0].object : null };
+    }
+
+    /**
+     * Apply the hover visual (enlarged + fully opaque) to a sprite, restoring
+     * the previously hovered one. Pass `null` to clear.
+     * @param {any} sprite
+     */
+    _setGizmoHoverSprite(sprite) {
+        if (sprite === this._gizmoHovered) return;
+        if (this._gizmoHovered) {
+            this._gizmoHovered.scale.setScalar(this._gizmoBaseScale);
+            const base = this._gizmoHovered.userData.baseOpacity;
+            if (typeof base === 'number') this._gizmoHovered.material.opacity = base;
+        }
+        if (sprite) {
+            sprite.scale.setScalar(this._gizmoHoverScale);
+            sprite.material.opacity = 1.0;
+        }
+        this._gizmoHovered = sprite;
+    }
+
+    resetView() {
+        // Canonical home view: world-Z up, isometric-ish direction
+        // (+X, -Y, +Z) looking at the scene bbox center, then framed to fit.
+        // Replaces the old "hail-mary" reset — orientation is now always the
+        // same regardless of prior camera state, so Home is predictable.
+        this._camera.up.set(0, 0, 1);
+        const bbox = new THREE.Box3();
+        this._scene.traverse(/** @param {any} child */ child => {
+            if (!child.geometry) return;
+            if (child === this._gridHelper) return;
+            if (this._isClipHelper(child)) return;
+            child.updateWorldMatrix(true, false);
+            bbox.expandByObject(child);
+        });
+        const target = bbox.isEmpty()
+            ? new THREE.Vector3()
+            : bbox.getCenter(new THREE.Vector3());
+        this._controls.target.copy(target);
+        // Pre-orient along the canonical direction so _fitCameraToBox (which
+        // preserves whatever direction the camera is already pointing) puts
+        // the camera in the right spot after fitting.
+        const isoDir = new THREE.Vector3(1, -1, 1).normalize();
+        this._camera.position.copy(target).addScaledVector(isoDir, 1);
+        this._camera.lookAt(target);
         this._controls.update();
-        this.frameAll();
+        if (bbox.isEmpty()) {
+            // No scene yet — fall back to a sensible distance so the user
+            // isn't staring down at near-clipping at the origin.
+            this._camera.position.copy(target).addScaledVector(isoDir, 10);
+            this._camera.lookAt(target);
+            this._controls.update();
+        } else {
+            this._fitCameraToBox(bbox, 1.2);
+        }
     }
 
     frameAll() {

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -494,6 +494,10 @@
         .threejs-viewer .tjsv-view-home:focus {
             outline: none;
         }
+        .threejs-viewer .tjsv-view-home:focus-visible {
+            outline: 2px solid #66b3ff;
+            outline-offset: 2px;
+        }
     </style>
     <script type="importmap">
     {
@@ -642,7 +646,7 @@ const HTML_TEMPLATE = `<div class="tjsv-toolbar">
     <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
 </div>
 
-<button class="tjsv-view-home" title="Reset view (F)" tabindex="-1">
+<button class="tjsv-view-home" title="Reset view (F)" aria-label="Reset view">
     <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
         <path d="M3 11.5 L12 3 L21 11.5 M5 10 V20 H10 V14 H14 V20 H19 V10"
               fill="none" stroke="currentColor" stroke-width="2"
@@ -3855,6 +3859,7 @@ class ThreeJSViewer {
         this._clipThicknessSection = q('.tjsv-clip-thickness-section');
         this._clipClose = q('.tjsv-clip-close');
         this._animControlsEl = q('.tjsv-animation-controls');
+        this._animLiftCss = 0;
         this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
         this._timelineMarkersEl = q('.tjsv-timeline-markers');
@@ -4345,6 +4350,17 @@ class ThreeJSViewer {
         let node = child;
         while (node) {
             if (node === this._clipAnchor || node === this._clipGizmoHelper) return true;
+            node = node.parent;
+        }
+        return false;
+    }
+
+    /** @param {any} child */
+    _isPivotMarkerDescendant(child) {
+        if (!this._pivotMarker) return false;
+        let node = child;
+        while (node) {
+            if (node === this._pivotMarker) return true;
             node = node.parent;
         }
         return false;
@@ -4953,8 +4969,10 @@ class ThreeJSViewer {
 
         this._animControlsEl.classList.add('visible');
         // Reading offsetHeight forces layout so --tjsv-anim-lift reflects the
-        // now-visible toolbar; CSS uses it to shift the Home button up.
-        this.el.style.setProperty('--tjsv-anim-lift', `${this._animControlsEl.offsetHeight}px`);
+        // now-visible toolbar; CSS uses it to shift the Home button up. Cache
+        // the value for the gizmo hit-test / render-shim hot paths.
+        this._animLiftCss = this._animControlsEl.offsetHeight;
+        this.el.style.setProperty('--tjsv-anim-lift', `${this._animLiftCss}px`);
         this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
@@ -5021,6 +5039,7 @@ class ThreeJSViewer {
         this._animationPlaying = false;
         this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
+        this._animLiftCss = 0;
         this.el.style.setProperty('--tjsv-anim-lift', '0px');
         this._trackMode = 'off';
         this._trackTargetId = null;
@@ -6665,10 +6684,7 @@ class ThreeJSViewer {
         // Lift the ViewHelper above the animation toolbar when it's visible.
         // ViewHelper hardcodes setViewport(x, 0, dim, dim); we shim that one
         // call to add a Y offset matching the toolbar height.
-        const animEl = this._animControlsEl;
-        const lift = (animEl && animEl.classList.contains('visible'))
-            ? animEl.offsetHeight * window.devicePixelRatio
-            : 0;
+        const lift = (this._animLiftCss || 0) * window.devicePixelRatio;
         if (lift > 0) {
             // Cache the true original once so we don't re-wrap the wrapped
             // setViewport each frame (which would deepen the call chain by
@@ -6780,11 +6796,13 @@ class ThreeJSViewer {
 
     /**
      * CSS-pixel lift applied to the gizmo when the animation toolbar is
-     * visible — matches the render-time shim in the main loop.
+     * visible — matches the render-time shim in the main loop. Cached to
+     * avoid layout reads on every pointermove (hit-test) and every frame
+     * (render shim). Kept in sync by the show/hide paths that also set
+     * the --tjsv-anim-lift CSS var.
      */
     _gizmoLiftCss() {
-        const el = this._animControlsEl;
-        return (el && el.classList.contains('visible')) ? el.offsetHeight : 0;
+        return this._animLiftCss || 0;
     }
 
     /**
@@ -6799,8 +6817,8 @@ class ThreeJSViewer {
         const rect = dom.getBoundingClientRect();
         const dim = this._gizmoDim;
         const liftCss = this._gizmoLiftCss();
-        const offsetX = rect.left + dom.offsetWidth - dim;
-        const offsetY = rect.top + dom.offsetHeight - dim - liftCss;
+        const offsetX = rect.left + rect.width - dim;
+        const offsetY = rect.top + rect.height - dim - liftCss;
         const insideRect =
             e.clientX >= offsetX && e.clientX <= offsetX + dim &&
             e.clientY >= offsetY && e.clientY <= offsetY + dim;
@@ -6847,6 +6865,7 @@ class ThreeJSViewer {
             if (!child.geometry) return;
             if (child === this._gridHelper) return;
             if (this._isClipHelper(child)) return;
+            if (this._isPivotMarkerDescendant(child)) return;
             child.updateWorldMatrix(true, false);
             bbox.expandByObject(child);
         });
@@ -6878,6 +6897,7 @@ class ThreeJSViewer {
             if (!child.geometry) return;
             if (child === this._gridHelper) return;
             if (this._isClipHelper(child)) return;
+            if (this._isPivotMarkerDescendant(child)) return;
             child.updateWorldMatrix(true, false);
             bbox.expandByObject(child);
         });

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -123,3 +123,11 @@
     </div>
     <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
 </div>
+
+<button class="tjsv-view-home" title="Reset view (F)" tabindex="-1">
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
+        <path d="M3 11.5 L12 3 L21 11.5 M5 10 V20 H10 V14 H14 V20 H19 V10"
+              fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linejoin="round" stroke-linecap="round"/>
+    </svg>
+</button>

--- a/src/threejs_viewer/viewer/template.html
+++ b/src/threejs_viewer/viewer/template.html
@@ -124,7 +124,7 @@
     <div class="keyboard-hint">Space: Play/Pause | &larr;&rarr;: Step frames | Shift+&larr;&rarr;: Step 10 | Home/End: Jump | L: Loop | &uarr;&darr;: Speed</div>
 </div>
 
-<button class="tjsv-view-home" title="Reset view (F)" tabindex="-1">
+<button class="tjsv-view-home" title="Reset view (F)" aria-label="Reset view">
     <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
         <path d="M3 11.5 L12 3 L21 11.5 M5 10 V20 H10 V14 H14 V20 H19 V10"
               fill="none" stroke="currentColor" stroke-width="2"

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -483,3 +483,7 @@
 .threejs-viewer .tjsv-view-home:focus {
     outline: none;
 }
+.threejs-viewer .tjsv-view-home:focus-visible {
+    outline: 2px solid #66b3ff;
+    outline-offset: 2px;
+}

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -447,3 +447,39 @@
     color: #999;
     text-align: center;
 }
+
+/* Home button — centered inside the 128×128 ViewHelper area, shifts up
+   with the animation toolbar via --tjsv-anim-lift (set from JS). */
+.threejs-viewer .tjsv-view-home {
+    position: absolute;
+    right: 46px;
+    bottom: calc(46px + var(--tjsv-anim-lift, 0px));
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border-radius: 50%;
+    background: rgba(30, 30, 30, 0.72);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    color: #ddd;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    opacity: 0.75;
+    transition: background 0.15s, color 0.15s, opacity 0.15s, transform 0.15s;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+    z-index: 2;
+}
+.threejs-viewer .tjsv-view-home:hover {
+    background: rgba(60, 60, 60, 0.95);
+    color: white;
+    opacity: 1;
+    transform: scale(1.06);
+}
+.threejs-viewer .tjsv-view-home:active {
+    transform: scale(0.96);
+}
+.threejs-viewer .tjsv-view-home:focus {
+    outline: none;
+}

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -2788,6 +2788,7 @@ export class ThreeJSViewer {
         this._clipThicknessSection = q('.tjsv-clip-thickness-section');
         this._clipClose = q('.tjsv-clip-close');
         this._animControlsEl = q('.tjsv-animation-controls');
+        this._animLiftCss = 0;
         this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
         this._timelineMarkersEl = q('.tjsv-timeline-markers');
@@ -3278,6 +3279,17 @@ export class ThreeJSViewer {
         let node = child;
         while (node) {
             if (node === this._clipAnchor || node === this._clipGizmoHelper) return true;
+            node = node.parent;
+        }
+        return false;
+    }
+
+    /** @param {any} child */
+    _isPivotMarkerDescendant(child) {
+        if (!this._pivotMarker) return false;
+        let node = child;
+        while (node) {
+            if (node === this._pivotMarker) return true;
             node = node.parent;
         }
         return false;
@@ -3886,8 +3898,10 @@ export class ThreeJSViewer {
 
         this._animControlsEl.classList.add('visible');
         // Reading offsetHeight forces layout so --tjsv-anim-lift reflects the
-        // now-visible toolbar; CSS uses it to shift the Home button up.
-        this.el.style.setProperty('--tjsv-anim-lift', `${this._animControlsEl.offsetHeight}px`);
+        // now-visible toolbar; CSS uses it to shift the Home button up. Cache
+        // the value for the gizmo hit-test / render-shim hot paths.
+        this._animLiftCss = this._animControlsEl.offsetHeight;
+        this.el.style.setProperty('--tjsv-anim-lift', `${this._animLiftCss}px`);
         this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
@@ -3954,6 +3968,7 @@ export class ThreeJSViewer {
         this._animationPlaying = false;
         this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
+        this._animLiftCss = 0;
         this.el.style.setProperty('--tjsv-anim-lift', '0px');
         this._trackMode = 'off';
         this._trackTargetId = null;
@@ -5598,10 +5613,7 @@ export class ThreeJSViewer {
         // Lift the ViewHelper above the animation toolbar when it's visible.
         // ViewHelper hardcodes setViewport(x, 0, dim, dim); we shim that one
         // call to add a Y offset matching the toolbar height.
-        const animEl = this._animControlsEl;
-        const lift = (animEl && animEl.classList.contains('visible'))
-            ? animEl.offsetHeight * window.devicePixelRatio
-            : 0;
+        const lift = (this._animLiftCss || 0) * window.devicePixelRatio;
         if (lift > 0) {
             // Cache the true original once so we don't re-wrap the wrapped
             // setViewport each frame (which would deepen the call chain by
@@ -5713,11 +5725,13 @@ export class ThreeJSViewer {
 
     /**
      * CSS-pixel lift applied to the gizmo when the animation toolbar is
-     * visible — matches the render-time shim in the main loop.
+     * visible — matches the render-time shim in the main loop. Cached to
+     * avoid layout reads on every pointermove (hit-test) and every frame
+     * (render shim). Kept in sync by the show/hide paths that also set
+     * the --tjsv-anim-lift CSS var.
      */
     _gizmoLiftCss() {
-        const el = this._animControlsEl;
-        return (el && el.classList.contains('visible')) ? el.offsetHeight : 0;
+        return this._animLiftCss || 0;
     }
 
     /**
@@ -5732,8 +5746,8 @@ export class ThreeJSViewer {
         const rect = dom.getBoundingClientRect();
         const dim = this._gizmoDim;
         const liftCss = this._gizmoLiftCss();
-        const offsetX = rect.left + dom.offsetWidth - dim;
-        const offsetY = rect.top + dom.offsetHeight - dim - liftCss;
+        const offsetX = rect.left + rect.width - dim;
+        const offsetY = rect.top + rect.height - dim - liftCss;
         const insideRect =
             e.clientX >= offsetX && e.clientX <= offsetX + dim &&
             e.clientY >= offsetY && e.clientY <= offsetY + dim;
@@ -5780,6 +5794,7 @@ export class ThreeJSViewer {
             if (!child.geometry) return;
             if (child === this._gridHelper) return;
             if (this._isClipHelper(child)) return;
+            if (this._isPivotMarkerDescendant(child)) return;
             child.updateWorldMatrix(true, false);
             bbox.expandByObject(child);
         });
@@ -5811,6 +5826,7 @@ export class ThreeJSViewer {
             if (!child.geometry) return;
             if (child === this._gridHelper) return;
             if (this._isClipHelper(child)) return;
+            if (this._isPivotMarkerDescendant(child)) return;
             child.updateWorldMatrix(true, false);
             bbox.expandByObject(child);
         });

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -2239,8 +2239,10 @@ class CameraController {
         v._controls.target.copy(tgt);
         v._controls.update();
         v._clipGizmo.camera = v._camera;
+        v._setGizmoHoverSprite(null);
         v._viewHelper = new ViewHelper(v._camera, v._renderer.domElement);
         v._viewHelper.center = v._controls.target;
+        v._configureViewHelper(v._viewHelper);
         v._btnOrtho.textContent = '\u2B1A O';
         v._btnOrtho.classList.toggle('active', v._isOrtho);
     }
@@ -2786,6 +2788,7 @@ export class ThreeJSViewer {
         this._clipThicknessSection = q('.tjsv-clip-thickness-section');
         this._clipClose = q('.tjsv-clip-close');
         this._animControlsEl = q('.tjsv-animation-controls');
+        this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
         this._timelineMarkersEl = q('.tjsv-timeline-markers');
         this._currentTimeEl = q('.tjsv-current-time');
@@ -2945,12 +2948,53 @@ export class ThreeJSViewer {
                 if (md) md.ringColors = redRc;
             }
         };
-        // ViewHelper
+        // ViewHelper — axis sprites are enlarged for easier hit-testing, and a
+        // custom hover raycast lights up the sprite under the cursor so users
+        // can see when a click will actually land. Pointerdown inside the gizmo
+        // rect is suppressed at capture to prevent click-to-pivot from firing
+        // on near-misses.
+        this._gizmoDim = 128;
+        this._gizmoBaseScale = 1.4;
+        this._gizmoHoverScale = 1.75;
+        this._gizmoHoverRaycaster = new THREE.Raycaster();
+        this._gizmoHoverOrthoCam = new THREE.OrthographicCamera(-2, 2, 2, -2, 0, 4);
+        this._gizmoHoverOrthoCam.position.set(0, 0, 2);
+        this._gizmoHoverOrthoCam.updateMatrixWorld();
+        this._gizmoHovered = null;
         this._viewHelper = new ViewHelper(this._camera, this._renderer.domElement);
         this._viewHelper.center = this._controls.target;
+        this._configureViewHelper(this._viewHelper);
+
+        // Suppress click-to-pivot when the pointer is inside the gizmo rect.
+        // Runs at capture so it fires before ViewerControls' pointerdown listener.
+        this._renderer.domElement.addEventListener('pointerdown', (e) => {
+            if (this._gizmoHitTest(e).insideRect) {
+                e.stopImmediatePropagation();
+            }
+        }, true);
+
+        // Hover feedback: highlight the sprite under the cursor + pointer cursor.
+        this._renderer.domElement.addEventListener('pointermove', (e) => {
+            if (this._viewHelper.animating) return;
+            const { hit } = this._gizmoHitTest(e);
+            this._setGizmoHoverSprite(hit);
+            this._renderer.domElement.style.cursor = hit ? 'pointer' : '';
+        });
+        this._renderer.domElement.addEventListener('pointerleave', () => {
+            this._setGizmoHoverSprite(null);
+            this._renderer.domElement.style.cursor = '';
+        });
+
         this._renderer.domElement.addEventListener('click', (e) => {
-            if (this._viewHelper.handleClick(e)) {
+            if (this._viewHelper.animating) return;
+            // ViewHelper.handleClick assumes the gizmo sits at bottom:0, but we
+            // lift it above the animation toolbar when visible — shim clientY
+            // so handleClick's raycast maps to the rendered location.
+            const liftCss = this._gizmoLiftCss();
+            const shim = { clientX: e.clientX, clientY: e.clientY + liftCss };
+            if (this._viewHelper.handleClick(/** @type {any} */ (shim))) {
                 this._controls.target.copy(this._viewHelper.center);
+                this._setGizmoHoverSprite(null);
             }
         });
         // Double-click an object to frame it; double-click empty space to reset.
@@ -3841,6 +3885,9 @@ export class ThreeJSViewer {
         }
 
         this._animControlsEl.classList.add('visible');
+        // Reading offsetHeight forces layout so --tjsv-anim-lift reflects the
+        // now-visible toolbar; CSS uses it to shift the Home button up.
+        this.el.style.setProperty('--tjsv-anim-lift', `${this._animControlsEl.offsetHeight}px`);
         this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
@@ -3907,6 +3954,7 @@ export class ThreeJSViewer {
         this._animationPlaying = false;
         this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
+        this.el.style.setProperty('--tjsv-anim-lift', '0px');
         this._trackMode = 'off';
         this._trackTargetId = null;
         this._trackHasLastPos = false;
@@ -4366,6 +4414,14 @@ export class ThreeJSViewer {
         this._btnTrack.addEventListener('click', () => this._cycleTrackMode());
         this.el.querySelector('.tjsv-btn-slower').addEventListener('click', () => this._stepSpeed(-1));
         this.el.querySelector('.tjsv-btn-faster').addEventListener('click', () => this._stepSpeed(1));
+
+        // Home button: sits centered in the ViewHelper area and resets the view.
+        if (this._viewHomeBtn) {
+            this._viewHomeBtn.addEventListener('click', () => {
+                this.resetView();
+                this._viewHomeBtn.blur();
+            });
+        }
 
         // Timeline scrubbing
         this._timelineContainer.addEventListener('mousedown', /** @param {MouseEvent} e */ (e) => {
@@ -5635,18 +5691,118 @@ export class ThreeJSViewer {
         this._fitCameraToBox(bbox, 1.5);
     }
 
-    resetView() {
-        // Hail-mary: reset camera up to world-Z, point at origin, then frame
-        // everything. Recovers from degenerate / inverted / lost states.
-        this._camera.up.set(0, 0, 1);
-        const dir = this._camera.position.clone().sub(this._controls.target);
-        if (dir.lengthSq() < 1e-10) {
-            this._camera.position.set(5, -5, 5);
+    // ========== ViewHelper (corner gizmo) ==========
+
+    /**
+     * Enlarge the ViewHelper's axis sprites so they have a bigger hit target
+     * and a more visible cue. Baseline opacity is captured for the hover
+     * restore. Called once per ViewHelper instance — the helper is re-created
+     * on every perspective/ortho swap.
+     * @param {any} helper
+     */
+    _configureViewHelper(helper) {
+        const sprites = [];
+        for (const child of helper.children) {
+            if (!child.userData || !child.userData.type) continue;
+            child.scale.setScalar(this._gizmoBaseScale);
+            child.userData.baseOpacity = child.material.opacity;
+            sprites.push(child);
         }
-        this._controls.target.set(0, 0, 0);
-        this._camera.lookAt(0, 0, 0);
+        helper.userData.interactiveSprites = sprites;
+    }
+
+    /**
+     * CSS-pixel lift applied to the gizmo when the animation toolbar is
+     * visible — matches the render-time shim in the main loop.
+     */
+    _gizmoLiftCss() {
+        const el = this._animControlsEl;
+        return (el && el.classList.contains('visible')) ? el.offsetHeight : 0;
+    }
+
+    /**
+     * Hit-test a pointer event against the ViewHelper's axis sprites. Returns
+     * whether the pointer is inside the 128×128 gizmo rect at all, plus the
+     * hovered sprite (null if no sprite under cursor).
+     * @param {PointerEvent | MouseEvent} e
+     * @returns {{ insideRect: boolean, hit: any }}
+     */
+    _gizmoHitTest(e) {
+        const dom = this._renderer.domElement;
+        const rect = dom.getBoundingClientRect();
+        const dim = this._gizmoDim;
+        const liftCss = this._gizmoLiftCss();
+        const offsetX = rect.left + dom.offsetWidth - dim;
+        const offsetY = rect.top + dom.offsetHeight - dim - liftCss;
+        const insideRect =
+            e.clientX >= offsetX && e.clientX <= offsetX + dim &&
+            e.clientY >= offsetY && e.clientY <= offsetY + dim;
+        if (!insideRect) return { insideRect: false, hit: null };
+        const sprites = this._viewHelper.userData.interactiveSprites;
+        if (!sprites || sprites.length === 0) return { insideRect: true, hit: null };
+        const ndcX = ((e.clientX - offsetX) / dim) * 2 - 1;
+        const ndcY = -((e.clientY - offsetY) / dim) * 2 + 1;
+        this._gizmoHoverRaycaster.setFromCamera(
+            new THREE.Vector2(ndcX, ndcY),
+            this._gizmoHoverOrthoCam,
+        );
+        const hits = this._gizmoHoverRaycaster.intersectObjects(sprites, false);
+        return { insideRect: true, hit: hits.length ? hits[0].object : null };
+    }
+
+    /**
+     * Apply the hover visual (enlarged + fully opaque) to a sprite, restoring
+     * the previously hovered one. Pass `null` to clear.
+     * @param {any} sprite
+     */
+    _setGizmoHoverSprite(sprite) {
+        if (sprite === this._gizmoHovered) return;
+        if (this._gizmoHovered) {
+            this._gizmoHovered.scale.setScalar(this._gizmoBaseScale);
+            const base = this._gizmoHovered.userData.baseOpacity;
+            if (typeof base === 'number') this._gizmoHovered.material.opacity = base;
+        }
+        if (sprite) {
+            sprite.scale.setScalar(this._gizmoHoverScale);
+            sprite.material.opacity = 1.0;
+        }
+        this._gizmoHovered = sprite;
+    }
+
+    resetView() {
+        // Canonical home view: world-Z up, isometric-ish direction
+        // (+X, -Y, +Z) looking at the scene bbox center, then framed to fit.
+        // Replaces the old "hail-mary" reset — orientation is now always the
+        // same regardless of prior camera state, so Home is predictable.
+        this._camera.up.set(0, 0, 1);
+        const bbox = new THREE.Box3();
+        this._scene.traverse(/** @param {any} child */ child => {
+            if (!child.geometry) return;
+            if (child === this._gridHelper) return;
+            if (this._isClipHelper(child)) return;
+            child.updateWorldMatrix(true, false);
+            bbox.expandByObject(child);
+        });
+        const target = bbox.isEmpty()
+            ? new THREE.Vector3()
+            : bbox.getCenter(new THREE.Vector3());
+        this._controls.target.copy(target);
+        // Pre-orient along the canonical direction so _fitCameraToBox (which
+        // preserves whatever direction the camera is already pointing) puts
+        // the camera in the right spot after fitting.
+        const isoDir = new THREE.Vector3(1, -1, 1).normalize();
+        this._camera.position.copy(target).addScaledVector(isoDir, 1);
+        this._camera.lookAt(target);
         this._controls.update();
-        this.frameAll();
+        if (bbox.isEmpty()) {
+            // No scene yet — fall back to a sensible distance so the user
+            // isn't staring down at near-clipping at the origin.
+            this._camera.position.copy(target).addScaledVector(isoDir, 10);
+            this._camera.lookAt(target);
+            this._controls.update();
+        } else {
+            this._fitCameraToBox(bbox, 1.2);
+        }
     }
 
     frameAll() {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -448,8 +448,11 @@ def test_view_helper_setviewport_shim_no_stack_overflow(viewer_client, viewer_pa
     result = viewer_page.evaluate(
         """() => {
             const v = window.threejsViewer;
-            // Force toolbar visible so the lift > 0 branch runs.
+            // Force toolbar visible so the lift > 0 branch runs. The render
+            // loop reads the cached CSS-pixel lift (updated by the show/hide
+            // paths) rather than offsetHeight; set it directly here.
             v._animControlsEl.classList.add('visible');
+            v._animLiftCss = 40;
             // Trigger many render passes synchronously.
             const origAnimate = v._animate.bind(v);
             for (let i = 0; i < 200; i++) {


### PR DESCRIPTION
## Summary

- Corner ViewHelper gizmo: bigger hit targets (sprites scaled 1.4×), hover highlight + `cursor: pointer` when a click will actually land.
- Suppresses click-to-pivot inside the 128×128 gizmo rect so near-misses don't accidentally relocate the orbit pivot.
- Adds a Home button centered in the empty middle of the gizmo; lifts above the animation toolbar via a `--tjsv-anim-lift` CSS variable.
- `resetView()` (Home button / F / Home key) now enforces a canonical orientation (world-Z up, isometric-ish `(+X, -Y, +Z)` from the bbox center) and frames all objects — predictable home, handles scenes centered off-origin.
- Fixes a small pre-existing bug: gizmo clicks missed their targets when the animation toolbar was visible (the gizmo renders lifted, but `handleClick` assumed it was at `bottom:0`). Now shimmed via the click handler.

## Screenshots

The Home button sits in the middle of the axis ring (axes are at the periphery, so it doesn't occlude any axis). On hover, the hovered axis sprite grows and becomes fully opaque.

## Test plan

- [ ] Pointer inside the gizmo rect → hovered axis highlights, `cursor: pointer`.
- [ ] Click an axis → camera animates to that orthogonal view.
- [ ] Click an empty area inside the gizmo rect → nothing happens (no pivot relocation, no axis change).
- [ ] Click outside the gizmo rect on an object → pivot still relocates as before.
- [ ] Press the Home button → camera resets to isometric-ish view framing all objects, works whether objects are at origin or off-origin.
- [ ] Load an animation → Home button shifts up above the toolbar; gizmo clicks still land correctly.
- [ ] Toggle ortho ⇄ perspective → gizmo hover/click continues to work after the camera swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)