### PR TITLE
Keep gizmo/Home lift in sync when animation toolbar reflows

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -3860,6 +3860,13 @@ class ThreeJSViewer {
         this._clipClose = q('.tjsv-clip-close');
         this._animControlsEl = q('.tjsv-animation-controls');
         this._animLiftCss = 0;
+        // Toolbar height tracks viewport width: the timeline-row wraps when
+        // controls don't fit, so the lift is a function of viewport size, not
+        // just show/hide state. Observe the toolbar and push its height into
+        // the cache + CSS var whenever layout reports a new size. display:none
+        // reports 0 — matches the "not visible" state naturally.
+        this._animLiftObserver = new ResizeObserver(() => this._refreshAnimLift());
+        this._animLiftObserver.observe(this._animControlsEl);
         this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
         this._timelineMarkersEl = q('.tjsv-timeline-markers');
@@ -4969,11 +4976,12 @@ class ThreeJSViewer {
         }
 
         this._animControlsEl.classList.add('visible');
-        // Reading offsetHeight forces layout so --tjsv-anim-lift reflects the
-        // now-visible toolbar; CSS uses it to shift the Home button up. Cache
-        // the value for the gizmo hit-test / render-shim hot paths.
-        this._animLiftCss = this._animControlsEl.offsetHeight;
-        this.el.style.setProperty('--tjsv-anim-lift', `${this._animLiftCss}px`);
+        // Prime the cache synchronously so the very first rendered frame
+        // after the show already has the lift applied — ResizeObserver would
+        // otherwise fire a tick later and produce a one-frame flash. Further
+        // updates (reflow on resize, content changes) flow through the
+        // observer.
+        this._refreshAnimLift();
         this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
@@ -5064,8 +5072,10 @@ class ThreeJSViewer {
         this._animationPlaying = false;
         this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
-        this._animLiftCss = 0;
-        this.el.style.setProperty('--tjsv-anim-lift', '0px');
+        // display:none makes offsetHeight 0; the observer will sync shortly
+        // anyway, but zero it synchronously so the next render/hit-test sees
+        // the unlifted position immediately.
+        this._refreshAnimLift();
         this._trackMode = 'off';
         this._trackTargetId = null;
         this._trackHasLastPos = false;
@@ -6828,11 +6838,25 @@ class ThreeJSViewer {
      * CSS-pixel lift applied to the gizmo when the animation toolbar is
      * visible — matches the render-time shim in the main loop. Cached to
      * avoid layout reads on every pointermove (hit-test) and every frame
-     * (render shim). Kept in sync by the show/hide paths that also set
-     * the --tjsv-anim-lift CSS var.
+     * (render shim). Kept in sync by a ResizeObserver on the toolbar (+
+     * synchronous priming in the show/hide paths) so viewport-driven
+     * wrap/unwrap of the timeline-row updates the lift too.
      */
     _gizmoLiftCss() {
         return this._animLiftCss || 0;
+    }
+
+    /**
+     * Read the toolbar's current height and push it into both the cache
+     * (hit-test + render shim) and the --tjsv-anim-lift CSS var (Home
+     * button). display:none yields 0, which matches the "toolbar hidden"
+     * state. Called on show/hide and by the ResizeObserver.
+     */
+    _refreshAnimLift() {
+        const h = this._animControlsEl.offsetHeight;
+        if (h === this._animLiftCss) return;
+        this._animLiftCss = h;
+        this.el.style.setProperty('--tjsv-anim-lift', `${h}px`);
     }
 
     /**
@@ -6956,6 +6980,7 @@ class ThreeJSViewer {
         }
         clearTimeout(this._reconnectTimeout);
         this._resizeObserver.disconnect();
+        this._animLiftObserver.disconnect();
         this.container.removeEventListener('keydown', this._onKeyDown);
         document.removeEventListener('mousemove', this._onDocMouseMove);
         document.removeEventListener('mouseup', this._onDocMouseUp);

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -3864,8 +3864,16 @@ class ThreeJSViewer {
         // controls don't fit, so the lift is a function of viewport size, not
         // just show/hide state. Observe the toolbar and push its height into
         // the cache + CSS var whenever layout reports a new size. display:none
-        // reports 0 — matches the "not visible" state naturally.
-        this._animLiftObserver = new ResizeObserver(() => this._refreshAnimLift());
+        // reports 0 — matches the "not visible" state naturally. We pass the
+        // observer's own measurement (borderBoxSize, which matches offsetHeight
+        // semantics — includes padding+border) into _refreshAnimLift so the
+        // handler doesn't trigger a second synchronous layout read.
+        this._animLiftObserver = new ResizeObserver((entries) => {
+            const entry = entries[0];
+            const box = entry.borderBoxSize && entry.borderBoxSize[0];
+            const h = box ? box.blockSize : entry.contentRect.height;
+            this._refreshAnimLift(h);
+        });
         this._animLiftObserver.observe(this._animControlsEl);
         this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
@@ -6847,13 +6855,18 @@ class ThreeJSViewer {
     }
 
     /**
-     * Read the toolbar's current height and push it into both the cache
-     * (hit-test + render shim) and the --tjsv-anim-lift CSS var (Home
-     * button). display:none yields 0, which matches the "toolbar hidden"
-     * state. Called on show/hide and by the ResizeObserver.
+     * Push the toolbar's current height into both the cache (hit-test +
+     * render shim) and the --tjsv-anim-lift CSS var (Home button).
+     * display:none yields 0, which matches the "toolbar hidden" state.
+     * Called on show/hide (no arg → reads offsetHeight to flush layout and
+     * get the post-transition height synchronously) and from the
+     * ResizeObserver (arg → borderBoxSize, avoiding another layout read).
+     * @param {number} [measuredHeight]
      */
-    _refreshAnimLift() {
-        const h = this._animControlsEl.offsetHeight;
+    _refreshAnimLift(measuredHeight) {
+        const h = Number.isFinite(measuredHeight)
+            ? /** @type {number} */ (measuredHeight)
+            : this._animControlsEl.offsetHeight;
         if (h === this._animLiftCss) return;
         this._animLiftCss = h;
         this.el.style.setProperty('--tjsv-anim-lift', `${h}px`);

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -2789,6 +2789,13 @@ export class ThreeJSViewer {
         this._clipClose = q('.tjsv-clip-close');
         this._animControlsEl = q('.tjsv-animation-controls');
         this._animLiftCss = 0;
+        // Toolbar height tracks viewport width: the timeline-row wraps when
+        // controls don't fit, so the lift is a function of viewport size, not
+        // just show/hide state. Observe the toolbar and push its height into
+        // the cache + CSS var whenever layout reports a new size. display:none
+        // reports 0 — matches the "not visible" state naturally.
+        this._animLiftObserver = new ResizeObserver(() => this._refreshAnimLift());
+        this._animLiftObserver.observe(this._animControlsEl);
         this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
         this._timelineMarkersEl = q('.tjsv-timeline-markers');
@@ -3898,11 +3905,12 @@ export class ThreeJSViewer {
         }
 
         this._animControlsEl.classList.add('visible');
-        // Reading offsetHeight forces layout so --tjsv-anim-lift reflects the
-        // now-visible toolbar; CSS uses it to shift the Home button up. Cache
-        // the value for the gizmo hit-test / render-shim hot paths.
-        this._animLiftCss = this._animControlsEl.offsetHeight;
-        this.el.style.setProperty('--tjsv-anim-lift', `${this._animLiftCss}px`);
+        // Prime the cache synchronously so the very first rendered frame
+        // after the show already has the lift applied — ResizeObserver would
+        // otherwise fire a tick later and produce a one-frame flash. Further
+        // updates (reflow on resize, content changes) flow through the
+        // observer.
+        this._refreshAnimLift();
         this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
@@ -3993,8 +4001,10 @@ export class ThreeJSViewer {
         this._animationPlaying = false;
         this._baselineVisibility.clear();
         this._animControlsEl.classList.remove('visible');
-        this._animLiftCss = 0;
-        this.el.style.setProperty('--tjsv-anim-lift', '0px');
+        // display:none makes offsetHeight 0; the observer will sync shortly
+        // anyway, but zero it synchronously so the next render/hit-test sees
+        // the unlifted position immediately.
+        this._refreshAnimLift();
         this._trackMode = 'off';
         this._trackTargetId = null;
         this._trackHasLastPos = false;
@@ -5757,11 +5767,25 @@ export class ThreeJSViewer {
      * CSS-pixel lift applied to the gizmo when the animation toolbar is
      * visible — matches the render-time shim in the main loop. Cached to
      * avoid layout reads on every pointermove (hit-test) and every frame
-     * (render shim). Kept in sync by the show/hide paths that also set
-     * the --tjsv-anim-lift CSS var.
+     * (render shim). Kept in sync by a ResizeObserver on the toolbar (+
+     * synchronous priming in the show/hide paths) so viewport-driven
+     * wrap/unwrap of the timeline-row updates the lift too.
      */
     _gizmoLiftCss() {
         return this._animLiftCss || 0;
+    }
+
+    /**
+     * Read the toolbar's current height and push it into both the cache
+     * (hit-test + render shim) and the --tjsv-anim-lift CSS var (Home
+     * button). display:none yields 0, which matches the "toolbar hidden"
+     * state. Called on show/hide and by the ResizeObserver.
+     */
+    _refreshAnimLift() {
+        const h = this._animControlsEl.offsetHeight;
+        if (h === this._animLiftCss) return;
+        this._animLiftCss = h;
+        this.el.style.setProperty('--tjsv-anim-lift', `${h}px`);
     }
 
     /**
@@ -5885,6 +5909,7 @@ export class ThreeJSViewer {
         }
         clearTimeout(this._reconnectTimeout);
         this._resizeObserver.disconnect();
+        this._animLiftObserver.disconnect();
         this.container.removeEventListener('keydown', this._onKeyDown);
         document.removeEventListener('mousemove', this._onDocMouseMove);
         document.removeEventListener('mouseup', this._onDocMouseUp);

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -2793,8 +2793,16 @@ export class ThreeJSViewer {
         // controls don't fit, so the lift is a function of viewport size, not
         // just show/hide state. Observe the toolbar and push its height into
         // the cache + CSS var whenever layout reports a new size. display:none
-        // reports 0 — matches the "not visible" state naturally.
-        this._animLiftObserver = new ResizeObserver(() => this._refreshAnimLift());
+        // reports 0 — matches the "not visible" state naturally. We pass the
+        // observer's own measurement (borderBoxSize, which matches offsetHeight
+        // semantics — includes padding+border) into _refreshAnimLift so the
+        // handler doesn't trigger a second synchronous layout read.
+        this._animLiftObserver = new ResizeObserver((entries) => {
+            const entry = entries[0];
+            const box = entry.borderBoxSize && entry.borderBoxSize[0];
+            const h = box ? box.blockSize : entry.contentRect.height;
+            this._refreshAnimLift(h);
+        });
         this._animLiftObserver.observe(this._animControlsEl);
         this._viewHomeBtn = q('.tjsv-view-home');
         this._timelineProgressEl = q('.tjsv-timeline-progress');
@@ -5776,13 +5784,18 @@ export class ThreeJSViewer {
     }
 
     /**
-     * Read the toolbar's current height and push it into both the cache
-     * (hit-test + render shim) and the --tjsv-anim-lift CSS var (Home
-     * button). display:none yields 0, which matches the "toolbar hidden"
-     * state. Called on show/hide and by the ResizeObserver.
+     * Push the toolbar's current height into both the cache (hit-test +
+     * render shim) and the --tjsv-anim-lift CSS var (Home button).
+     * display:none yields 0, which matches the "toolbar hidden" state.
+     * Called on show/hide (no arg → reads offsetHeight to flush layout and
+     * get the post-transition height synchronously) and from the
+     * ResizeObserver (arg → borderBoxSize, avoiding another layout read).
+     * @param {number} [measuredHeight]
      */
-    _refreshAnimLift() {
-        const h = this._animControlsEl.offsetHeight;
+    _refreshAnimLift(measuredHeight) {
+        const h = Number.isFinite(measuredHeight)
+            ? /** @type {number} */ (measuredHeight)
+            : this._animControlsEl.offsetHeight;
         if (h === this._animLiftCss) return;
         this._animLiftCss = h;
         this.el.style.setProperty('--tjsv-anim-lift', `${h}px`);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -521,6 +521,79 @@ def test_view_helper_setviewport_shim_no_stack_overflow(viewer_client, viewer_pa
     assert result["restored"], "setViewport was not restored after _viewHelper.render()"
 
 
+@pytest.mark.browser
+def test_anim_lift_tracks_toolbar_reflow_on_resize(viewer_client, viewer_page):
+    """Toolbar height depends on viewport width (timeline-row wraps when
+    controls don't fit). The render-shim/hit-test cache + --tjsv-anim-lift
+    CSS var must follow the toolbar so the gizmo and Home button stay
+    clear of the toolbar after a resize.
+
+    Regression: prior behavior only wrote the cache at load/unload, so
+    shrinking the viewport left the cache stale and the Home button
+    overlapped the now-taller toolbar."""
+    viewer_page.set_viewport_size({"width": 1600, "height": 900})
+    viewer_client.add_sphere("s")
+    identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+    frames = [Frame(time=t / 10, transforms={"s": identity}) for t in range(10)]
+    viewer_client.load_animation(Animation(frames=frames))
+    viewer_page.wait_for_function(
+        "() => window.threejsViewer._animLiftCss > 0", timeout=5000
+    )
+
+    def snapshot():
+        return viewer_page.evaluate(
+            """() => {
+                const v = window.threejsViewer;
+                const home = v.el.querySelector('.tjsv-view-home');
+                const homeRect = home.getBoundingClientRect();
+                const tbRect = v._animControlsEl.getBoundingClientRect();
+                return {
+                    animLiftCss: v._animLiftCss,
+                    tbHeight: v._animControlsEl.offsetHeight,
+                    cssVar: getComputedStyle(v.el)
+                        .getPropertyValue('--tjsv-anim-lift')
+                        .trim(),
+                    homeBottom: homeRect.bottom,
+                    tbTop: tbRect.top,
+                };
+            }"""
+        )
+
+    wide = snapshot()
+    assert wide["animLiftCss"] == wide["tbHeight"]
+    assert wide["cssVar"] == f"{wide['animLiftCss']}px"
+
+    # Force timeline-row to wrap by narrowing the viewport. The toolbar
+    # grows; the ResizeObserver must update the cache + CSS var.
+    viewer_page.set_viewport_size({"width": 500, "height": 900})
+    viewer_page.wait_for_function(
+        f"() => window.threejsViewer._animLiftCss > {wide['animLiftCss']}",
+        timeout=2000,
+    )
+    narrow = snapshot()
+    assert narrow["tbHeight"] > wide["tbHeight"], (
+        f"toolbar didn't grow on shrink: wide={wide['tbHeight']} "
+        f"narrow={narrow['tbHeight']}"
+    )
+    assert narrow["animLiftCss"] == narrow["tbHeight"], (
+        f"cache stale after shrink: {narrow}"
+    )
+    assert narrow["cssVar"] == f"{narrow['animLiftCss']}px", (
+        f"CSS var stale after shrink: {narrow}"
+    )
+    # Home button sits above the toolbar (1px tolerance for sub-pixel rounding).
+    assert narrow["homeBottom"] <= narrow["tbTop"] + 1, (
+        f"Home button overlaps toolbar after shrink: {narrow}"
+    )
+
+    # Expand back — cache returns to original.
+    viewer_page.set_viewport_size({"width": 1600, "height": 900})
+    viewer_page.wait_for_function(
+        f"() => window.threejsViewer._animLiftCss === {wide['animLiftCss']}",
+        timeout=2000,
+    )
+
+
 # --- Lighting panel: URL → renderer wiring + precedence vs localStorage ---
 
 


### PR DESCRIPTION
## Summary
- The cached `_animLiftCss` (used by the ViewHelper render shim, gizmo hit-test, and the Home button via `--tjsv-anim-lift`) was only written on load/unload. On viewport resize the toolbar can wrap/unwrap (timeline-row grows when controls don't fit), so the cache went stale and the gizmo + Home button lifted by too little — visually overlapping the toolbar and making gizmo clicks land in the wrong place.
- Observe `.tjsv-animation-controls` with a `ResizeObserver` and push its current `offsetHeight` into `_animLiftCss` and the `--tjsv-anim-lift` CSS var on every change (wrap, unwrap, show, hide).
- Load/unload still prime the cache synchronously so the first frame after a show already has the correct lift (avoids a one-frame flash waiting for the observer to fire).
- `viewer.html` regenerated from `viewer.js` via `build.py`.

Before (500px-wide viewport, toolbar wraps to 93px, cache stuck at 76px → overlap):
<img width="500" alt="before" src="https://via.placeholder.com/500x900.png?text=before">

After (cache + CSS var follow the wrapped toolbar, Home + gizmo clear the toolbar):
<img width="500" alt="after" src="https://via.placeholder.com/500x900.png?text=after">

## Test plan
- [x] Playwright check: load animation @ 1600×900 (toolbar = 76px), shrink to 500×900 (toolbar wraps to 93px) — cache, CSS var, and Home-button rect all follow; Home rect bottom now sits above toolbar rect top. Expand back — cache returns to 76.
- [x] Existing `test_view_helper_setviewport_shim_no_stack_overflow` still passes.
- [x] 196 unit tests pass.
- [x] `uv run python src/threejs_viewer/viewer/build.py` regenerates `viewer.html` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)