### PR TITLE
fix: baseline visibility survives async model load

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -5320,6 +5320,11 @@ class ThreeJSViewer {
             obj.userData.id = id;
             this._applyTransform(obj, objData.transform);
             if (objData.visible === false) obj.visible = false;
+            // A set_scene_visibility that arrived during the async load
+            // recorded a baseline with no object to apply to; honour it
+            // now so the request isn't silently dropped behind objData.visible.
+            const baseline = this._baselineVisibility.get(id);
+            if (baseline !== undefined) obj.visible = baseline;
             this._deleteObject(id);
             this._addToParentOrScene(obj, parentId);
             this._objects.set(id, obj);
@@ -5428,6 +5433,11 @@ class ThreeJSViewer {
         // cleared. Safe to call unconditionally — the load handlers'
         // post-delete insert path has already passed its own token check.
         this._claimLoadToken(id);
+        // Prune any recorded baseline so set_scene_visibility entries for
+        // never-loaded or explicitly-deleted ids don't accumulate. _addObject
+        // reads the baseline into a local before calling _deleteObject, so the
+        // race fix is unaffected.
+        this._baselineVisibility.delete(id);
         const obj = this._objects.get(id);
         if (obj) {
             /** @type {string[]} */
@@ -5482,11 +5492,13 @@ class ThreeJSViewer {
     /** @param {Record<string, boolean>} visibility */
     _setSceneVisibility(visibility) {
         for (const [id, visible] of Object.entries(visibility)) {
+            // Always remember the desired baseline, even when the id
+            // hasn't loaded yet. _addObject reads back from this map
+            // when an async model load resolves so a visibility request
+            // that arrived during the load isn't silently dropped.
+            this._baselineVisibility.set(id, visible);
             const obj = this._objects.get(id);
-            if (obj) {
-                obj.visible = visible;
-                this._baselineVisibility.set(id, visible);
-            }
+            if (obj) obj.visible = visible;
         }
     }
 

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -4249,13 +4249,9 @@ export class ThreeJSViewer {
             obj.userData.id = id;
             this._applyTransform(obj, objData.transform);
             if (objData.visible === false) obj.visible = false;
-            // If a `set_scene_visibility` arrived for this id BEFORE the
-            // async model load resolved, the desired baseline was
-            // recorded but had no object to apply to. Honour it now —
-            // otherwise the loaded object would stay at the message's
-            // initial `visible: false`, leaving large GLB fixtures
-            // (cabinets, consoles, …) permanently hidden after a
-            // cell switch.
+            // A set_scene_visibility that arrived during the async load
+            // recorded a baseline with no object to apply to; honour it
+            // now so the request isn't silently dropped behind objData.visible.
             const baseline = this._baselineVisibility.get(id);
             if (baseline !== undefined) obj.visible = baseline;
             this._deleteObject(id);
@@ -4366,6 +4362,11 @@ export class ThreeJSViewer {
         // cleared. Safe to call unconditionally — the load handlers'
         // post-delete insert path has already passed its own token check.
         this._claimLoadToken(id);
+        // Prune any recorded baseline so set_scene_visibility entries for
+        // never-loaded or explicitly-deleted ids don't accumulate. _addObject
+        // reads the baseline into a local before calling _deleteObject, so the
+        // race fix is unaffected.
+        this._baselineVisibility.delete(id);
         const obj = this._objects.get(id);
         if (obj) {
             /** @type {string[]} */

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -4249,6 +4249,15 @@ export class ThreeJSViewer {
             obj.userData.id = id;
             this._applyTransform(obj, objData.transform);
             if (objData.visible === false) obj.visible = false;
+            // If a `set_scene_visibility` arrived for this id BEFORE the
+            // async model load resolved, the desired baseline was
+            // recorded but had no object to apply to. Honour it now —
+            // otherwise the loaded object would stay at the message's
+            // initial `visible: false`, leaving large GLB fixtures
+            // (cabinets, consoles, …) permanently hidden after a
+            // cell switch.
+            const baseline = this._baselineVisibility.get(id);
+            if (baseline !== undefined) obj.visible = baseline;
             this._deleteObject(id);
             this._addToParentOrScene(obj, parentId);
             this._objects.set(id, obj);
@@ -4411,11 +4420,13 @@ export class ThreeJSViewer {
     /** @param {Record<string, boolean>} visibility */
     _setSceneVisibility(visibility) {
         for (const [id, visible] of Object.entries(visibility)) {
+            // Always remember the desired baseline, even when the id
+            // hasn't loaded yet. _addObject reads back from this map
+            // when an async model load resolves so a visibility request
+            // that arrived during the load isn't silently dropped.
+            this._baselineVisibility.set(id, visible);
             const obj = this._objects.get(id);
-            if (obj) {
-                obj.visible = visible;
-                this._baselineVisibility.set(id, visible);
-            }
+            if (obj) obj.visible = visible;
         }
     }
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -63,6 +63,36 @@ def test_visibility(viewer_client, viewer_page):
 
 
 @pytest.mark.browser
+def test_set_scene_visibility_before_add_is_honoured(viewer_client, viewer_page):
+    """set_scene_visibility for an id that doesn't exist yet must apply once the
+    object loads. Regression test for the race where a visibility flip arriving
+    during a slow GLB fetch was silently dropped, leaving the loaded object
+    permanently at its initial `visible` state (PR #47)."""
+    viewer_client.set_scene_visibility({"m1": False})
+    time.sleep(0.05)
+    viewer_client.add_box("m1")
+    time.sleep(0.1)
+    objects = viewer_client.query_scene()["objects"]
+    assert "m1" in objects
+    assert objects["m1"]["visible"] is False
+
+
+@pytest.mark.browser
+def test_baseline_visibility_pruned_on_delete(viewer_client, viewer_page):
+    """Deleting an object prunes its baseline so a later re-add isn't shadowed
+    by stale visibility from a prior set_scene_visibility."""
+    viewer_client.add_box("m1")
+    viewer_client.set_scene_visibility({"m1": False})
+    time.sleep(0.05)
+    viewer_client.delete("m1")
+    time.sleep(0.05)
+    viewer_client.add_box("m1")
+    time.sleep(0.1)
+    objects = viewer_client.query_scene()["objects"]
+    assert objects["m1"]["visible"] is True
+
+
+@pytest.mark.browser
 def test_clear_scene(viewer_client, viewer_page):
     """clear() removes all objects."""
     viewer_client.add_box("a")


### PR DESCRIPTION
## Summary

\`_setSceneVisibility\` used to discard the request when the id wasn't in \`_objects\` yet. Combined with \`_addObject\` finishing later, a \`set_scene_visibility\` that arrived during a slow GLB fetch was silently dropped — the loaded object then honoured only the add_object's initial \`visible:false\`, staying permanently hidden.

Surfaced in ribweaver as a cell-switch bug: switching cells while on the Simulate step hid the larger GLB fixtures (cabinets, consoles, big tables) until a page reload. Their GLBs took longer to fetch than the visibility flip, so the flip ran against an empty \`_objects\` map.

## Fix

- \`_setSceneVisibility\` always records the desired baseline in \`_baselineVisibility\`, even when the id hasn't loaded yet.
- \`_addObject\` consults \`_baselineVisibility\` after the model load resolves and applies it after the message's \`visible\` field — so a \`setCellVisible(true)\` that arrived during the load now sticks once the GLB lands.

## Test plan

- [ ] Manual: ribweaver-web, switch cells while on the Simulate step. Verify static furniture (cabinets, consoles, large tables) stays visible after the switch — no page reload required.
- [ ] Manual: cold reload remains correct (cell hidden on Input step, visible on Simulate).