### PR TITLE
Example 11: cross-bead sine modulation + static camera

### DIFF
--- a/examples/11_toolpath.py
+++ b/examples/11_toolpath.py
@@ -20,8 +20,9 @@ from threejs_viewer import Animation, Toolpath, viewer
 
 
 N_POINTS = 1_000_000
-N_TURNS = 1_000
+N_TURNS = 300
 HEIGHT = 9.0
+WAVES_PER_ROTATION = 100.5  # cross-bead sine cycles per layer (.5 → brick stagger)
 
 
 def spiral_vase(
@@ -77,6 +78,17 @@ def spiral_vase(
     ripple_strength = 1.0 - 0.6 * np.abs(t - 0.45) ** 0.8
     r += r * ripple * ripple_strength
 
+    # Cross-bead modulation: a sine wiggling the spine in the cross-bead
+    # (radial) direction.  Amplitude = a fraction of bead width, ramped from 0
+    # on the first layer to full strength on the top layer.  The wave is driven
+    # by a fixed number of cycles per rotation; a non-integer count (e.g. 100.5)
+    # advances the phase by an extra half-wave each turn, so consecutive layers
+    # land staggered by half a wavelength (brick pattern).
+    bead_w = HEIGHT / N_TURNS * 4
+    amplitude = 0.2 * bead_w
+    phase = WAVES_PER_ROTATION * angle
+    r = r + amplitude * t * np.sin(phase)  # ramp: 0 at base → max at top
+
     # Slight ellipse squash for asymmetry
     x = r * 1.08 * np.cos(angle)
     y = r * 0.93 * np.sin(angle)
@@ -105,7 +117,7 @@ tp = Toolpath.from_points(
 
 # Bead (parametric tube — chamfered hex cross-section, built client-side)
 tp.colorize("viridis")
-v.add_toolpath("path_tube", tp, roughness=0.4, metalness=0.15)
+v.add_toolpath("path_tube", tp, roughness=0.55, metalness=0.75)
 
 # Nozzle: tapered cylinder hovering above the path tip
 bead_width = HEIGHT / N_TURNS * 4
@@ -139,7 +151,7 @@ transforms[:, 1, 13] = tips[:, 1]
 transforms[:, 1, 14] = nz_z
 
 # Build animation — fully binary, linear interpolation fills in 60 fps
-animation = Animation(loop=True, camera_follow="nozzle")
+animation = Animation(loop=True, camera_follow=None)
 animation.set_frame_times(frame_times)
 animation.set_transform_data(["path_tube", "nozzle"], transforms)
 animation.set_draw_range_data(["path_tube"], draw_fracs[:, None])

--- a/examples/11_toolpath.py
+++ b/examples/11_toolpath.py
@@ -84,7 +84,7 @@ def spiral_vase(
     # by a fixed number of cycles per rotation; a non-integer count (e.g. 100.5)
     # advances the phase by an extra half-wave each turn, so consecutive layers
     # land staggered by half a wavelength (brick pattern).
-    bead_w = HEIGHT / N_TURNS * 4
+    bead_w = height / n_turns * 4
     amplitude = 0.2 * bead_w
     phase = WAVES_PER_ROTATION * angle
     r = r + amplitude * t * np.sin(phase)  # ramp: 0 at base → max at top


### PR DESCRIPTION
## Summary

Enhances `examples/11_toolpath.py` (the spiral-vase parametric-tube demo) with a cross-bead surface texture and a few presentation tweaks.

- **Cross-bead sine modulation**: adds a high-frequency radial (cross-bead) sine to the vase spine, ramped from zero on the first layer to full strength at the rim. Driven by a configurable `WAVES_PER_ROTATION` constant — the `.5` in `100.5` advances the phase an extra half-wave each turn, so consecutive layers land staggered by half a wavelength (a brick pattern), no per-layer bookkeeping needed.
- **`N_TURNS` 1000 → 300** for a coarser, more legible bead.
- **Glossier bead material** (`roughness=0.55, metalness=0.75`).
- **Static camera** (`camera_follow=None`) so the whole vase forms in view instead of chasing the nozzle.

## Test plan

- `uv run ruff check examples/11_toolpath.py` — passes
- `uv run ruff format --check examples/11_toolpath.py` — passes
- Geometry generator smoke-tested: produces finite points, z spans 0→HEIGHT

🤖 Generated with [Claude Code](https://claude.com/claude-code)