### PR TITLE
Review follow-ups: falsy-zero guards, add_points validation, swept-tool cap fixes + draw_ranges test

### DIFF
--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -1010,6 +1010,11 @@ class ViewerClient:
         has_vertex_colors = False
         if colors is not None:
             colors = np.asarray(colors)
+            if colors.shape[0] != n_points:
+                raise ValueError(
+                    f"colors must have length {n_points} (one per point), "
+                    f"got {colors.shape[0]}"
+                )
             if colors.ndim == 1:
                 if cmin is None:
                     cmin = float(colors.min())

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -1003,17 +1003,20 @@ class ViewerClient:
         with :meth:`set_draw_range` or the ``draw_ranges`` animation channel —
         the fraction maps onto the leading ``frac * N`` points of the buffer.
         """
-        positions = np.ascontiguousarray(positions, dtype=np.float32).reshape(-1)
-        n_points = len(positions) // 3
+        # reshape(-1, 3) enforces (N, 3) or a 1D multiple of 3 — a stray length
+        # would otherwise be silently truncated by // 3.
+        positions = np.ascontiguousarray(positions, dtype=np.float32).reshape(-1, 3)
+        n_points = positions.shape[0]
+        positions = positions.reshape(-1)
 
         color_bytes = b""
         has_vertex_colors = False
         if colors is not None:
             colors = np.asarray(colors)
-            if colors.shape[0] != n_points:
+            if colors.ndim == 0 or colors.shape[0] != n_points:
                 raise ValueError(
                     f"colors must have length {n_points} (one per point), "
-                    f"got {colors.shape[0]}"
+                    f"got shape {colors.shape}"
                 )
             if colors.ndim == 1:
                 if cmin is None:
@@ -1349,7 +1352,8 @@ class ViewerClient:
             axes: (N, 3) float32 unit tool axis per station (tip -> holder).
                 Normalized on the client; a zero axis is an error.
             profile: (M, 2) float32 ``(height_along_axis, radius)`` pairs,
-                M >= 2, ascending in height. Radii must be >= 0.
+                M >= 2, non-decreasing in height (equal heights = a vertical
+                step in the silhouette). Radii must be >= 0.
             colors: Optional (N,) uint32 packed ``0x00RRGGBB``, one color per
                 station (e.g. reorientation rate or shank clearance mapped to
                 a heatmap). Linearly interpolated along the path.
@@ -1389,6 +1393,11 @@ class ViewerClient:
             raise ValueError(f"profile needs >= 2 (height, radius) rows, got {m}")
         if not np.all(np.isfinite(profile_arr)) or np.any(profile_arr[:, 1] < 0):
             raise ValueError("profile heights/radii must be finite and radii >= 0")
+        # Heights must be non-decreasing (equal is allowed — a vertical step in
+        # the silhouette, e.g. a shank shoulder). Out-of-order heights would loft
+        # a backwards/self-crossing sweep.
+        if np.any(np.diff(profile_arr[:, 0]) < 0):
+            raise ValueError("profile heights must be non-decreasing (tip -> holder)")
 
         sections = int(sections)
         if sections < 3:

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -5045,33 +5045,23 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
         }
     }
 
-    // --- Indices. Station-major so draw_range advances along the path. ---
-    // Side faces: per level l, connect station k ring to station k+1 ring.
+    // --- Indices. Order: start cap → side loft (station-major) → end cap, so a
+    // partial draw_range reveal shows a body closed at its origin that grows
+    // along the path, with only the far (frontier) cap appearing last. ---
     const indicesPerRingPair = L * sections * 6;
     const ringPairCount = N - 1;
-    // End caps: revolution wall (L-1 bands) + a fan for any open end ring.
+    // End caps: revolution wall (L-1 bands) + a triangle fan (sections-2 tris)
+    // for any open end ring.
     const r0End = pr[0], r1End = pr[L - 1];
     const capBandsPerEnd = (L - 1) * sections * 6;
-    const cap0Fan = r0End > 1e-9 ? sections * 3 : 0;
-    const cap1Fan = r1End > 1e-9 ? sections * 3 : 0;
+    const cap0Fan = r0End > 1e-9 ? (sections - 2) * 3 : 0;
+    const cap1Fan = r1End > 1e-9 ? (sections - 2) * 3 : 0;
     const capIndexCount = 2 * capBandsPerEnd + cap0Fan + cap1Fan;
     const indices = new Uint32Array(ringPairCount * indicesPerRingPair + capIndexCount);
     let w = 0;
     const ringStart = (k, l) => (k * L + l) * sections;
-    // Side loft (station-major).
-    for (let k = 0; k < N - 1; k++) {
-        for (let l = 0; l < L; l++) {
-            const a0 = ringStart(k, l), b0 = ringStart(k + 1, l);
-            for (let s = 0; s < sections; s++) {
-                const s1 = (s + 1) % sections;
-                const a = a0 + s, an = a0 + s1, b = b0 + s, bn = b0 + s1;
-                indices[w++] = a; indices[w++] = b; indices[w++] = bn;
-                indices[w++] = a; indices[w++] = bn; indices[w++] = an;
-            }
-        }
-    }
-    // End-cap revolution walls + fans. Appended after the side faces so a
-    // partial draw_range grows the body before the far cap appears.
+    // Revolution wall closing the tool-body shell at one station (connects
+    // consecutive profile levels around the axis).
     const addCap = (k, flip) => {
         for (let l = 0; l < L - 1; l++) {
             const a0 = ringStart(k, l), b0 = ringStart(k, l + 1);
@@ -5089,8 +5079,8 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
         }
     };
     const addFan = (k, l, flip) => {
-        // Fan the open ring at level l to its centre (a fresh vertex appended
-        // to positions/colors is avoided by triangulating around vertex 0).
+        // Fan the open ring at level l to its centre, triangulating around
+        // vertex 0 (sections-2 triangles) so no extra centre vertex is needed.
         const base = ringStart(k, l);
         for (let s = 1; s < sections - 1; s++) {
             const a = base, b = base + s, c = base + s + 1;
@@ -5098,9 +5088,23 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
             else { indices[w++] = a; indices[w++] = c; indices[w++] = b; }
         }
     };
+    // Start cap first, so the origin end is closed from the first reveal frame.
     addCap(0, true);             // start cap faces inward (toward -path)
-    addCap(N - 1, false);        // end cap faces outward
     if (cap0Fan) addFan(0, 0, true);
+    // Side loft (station-major): per level l, connect station k ring to k+1.
+    for (let k = 0; k < N - 1; k++) {
+        for (let l = 0; l < L; l++) {
+            const a0 = ringStart(k, l), b0 = ringStart(k + 1, l);
+            for (let s = 0; s < sections; s++) {
+                const s1 = (s + 1) % sections;
+                const a = a0 + s, an = a0 + s1, b = b0 + s, bn = b0 + s1;
+                indices[w++] = a; indices[w++] = b; indices[w++] = bn;
+                indices[w++] = a; indices[w++] = bn; indices[w++] = an;
+            }
+        }
+    }
+    // End cap last (the frontier of the reveal).
+    addCap(N - 1, false);        // end cap faces outward
     if (cap1Fan) addFan(N - 1, L - 1, false);
 
     const geometry = new THREE.BufferGeometry();
@@ -9719,7 +9723,7 @@ class ThreeJSViewer {
                                 // the material into vertexColors mode.
                                 /** @type {any} */
                                 const matOpts = {
-                                    size: data.size || 2.0,
+                                    size: data.size ?? 2.0,
                                     sizeAttenuation: data.sizeAttenuation !== false,
                                 };
                                 if (data.hasVertexColors) {
@@ -9731,7 +9735,7 @@ class ThreeJSViewer {
                                     geometry.setAttribute('color', new THREE.Float32BufferAttribute(colorData, 3));
                                     matOpts.vertexColors = true;
                                 } else {
-                                    matOpts.color = data.color || 0xffffff;
+                                    matOpts.color = data.color ?? 0xffffff;
                                 }
                                 const material = new THREE.PointsMaterial(matOpts);
                                 const points = new THREE.Points(geometry, material);
@@ -10302,7 +10306,7 @@ class ThreeJSViewer {
                                 );
                                 const opacity = data.opacity !== undefined ? data.opacity : 1;
                                 const material = new THREE.MeshStandardMaterial({
-                                    color: hasColors ? 0xffffff : (data.color || 0x9aa0a6),
+                                    color: hasColors ? 0xffffff : (data.color ?? 0x9aa0a6),
                                     metalness: data.metalness !== undefined ? data.metalness : 0.3,
                                     roughness: data.roughness !== undefined ? data.roughness : 0.6,
                                     opacity,

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -5057,7 +5057,10 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
     const cap0Fan = r0End > 1e-9 ? (sections - 2) * 3 : 0;
     const cap1Fan = r1End > 1e-9 ? (sections - 2) * 3 : 0;
     const capIndexCount = 2 * capBandsPerEnd + cap0Fan + cap1Fan;
-    const indices = new Uint32Array(ringPairCount * indicesPerRingPair + capIndexCount);
+    // 16-bit indices below 64k verts (WebGL1-friendly, half the memory), 32-bit
+    // above — matching the parametric-tube builder.
+    const IndexCtor = N * L * sections > 65535 ? Uint32Array : Uint16Array;
+    const indices = new IndexCtor(ringPairCount * indicesPerRingPair + capIndexCount);
     let w = 0;
     const ringStart = (k, l) => (k * L + l) * sections;
     // Revolution wall closing the tool-body shell at one station (connects
@@ -5079,8 +5082,8 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
         }
     };
     const addFan = (k, l, flip) => {
-        // Fan the open ring at level l to its centre, triangulating around
-        // vertex 0 (sections-2 triangles) so no extra centre vertex is needed.
+        // Triangulate the open ring at level l as a fan rooted at its first
+        // vertex (sections-2 triangles) — no extra centre vertex needed.
         const base = ringStart(k, l);
         for (let s = 1; s < sections - 1; s++) {
             const a = base, b = base + s, c = base + s + 1;
@@ -11176,6 +11179,9 @@ class ThreeJSViewer {
         this._controls.dispose();
         this._clipGizmo.dispose();
         this._clipMoveGizmo.dispose();
+        // TransformControls.dispose() doesn't detach the helper it added to the
+        // scene — remove both clip gizmo helpers so teardown frees them.
+        this._scene.remove(this._clipGizmoHelper, this._clipMoveGizmoHelper);
         this.el.remove();
     }
 }

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -3950,7 +3950,10 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
     const cap0Fan = r0End > 1e-9 ? (sections - 2) * 3 : 0;
     const cap1Fan = r1End > 1e-9 ? (sections - 2) * 3 : 0;
     const capIndexCount = 2 * capBandsPerEnd + cap0Fan + cap1Fan;
-    const indices = new Uint32Array(ringPairCount * indicesPerRingPair + capIndexCount);
+    // 16-bit indices below 64k verts (WebGL1-friendly, half the memory), 32-bit
+    // above — matching the parametric-tube builder.
+    const IndexCtor = N * L * sections > 65535 ? Uint32Array : Uint16Array;
+    const indices = new IndexCtor(ringPairCount * indicesPerRingPair + capIndexCount);
     let w = 0;
     const ringStart = (k, l) => (k * L + l) * sections;
     // Revolution wall closing the tool-body shell at one station (connects
@@ -3972,8 +3975,8 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
         }
     };
     const addFan = (k, l, flip) => {
-        // Fan the open ring at level l to its centre, triangulating around
-        // vertex 0 (sections-2 triangles) so no extra centre vertex is needed.
+        // Triangulate the open ring at level l as a fan rooted at its first
+        // vertex (sections-2 triangles) — no extra centre vertex needed.
         const base = ringStart(k, l);
         for (let s = 1; s < sections - 1; s++) {
             const a = base, b = base + s, c = base + s + 1;
@@ -10069,6 +10072,9 @@ export class ThreeJSViewer {
         this._controls.dispose();
         this._clipGizmo.dispose();
         this._clipMoveGizmo.dispose();
+        // TransformControls.dispose() doesn't detach the helper it added to the
+        // scene — remove both clip gizmo helpers so teardown frees them.
+        this._scene.remove(this._clipGizmoHelper, this._clipMoveGizmoHelper);
         this.el.remove();
     }
 }

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -3938,33 +3938,23 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
         }
     }
 
-    // --- Indices. Station-major so draw_range advances along the path. ---
-    // Side faces: per level l, connect station k ring to station k+1 ring.
+    // --- Indices. Order: start cap → side loft (station-major) → end cap, so a
+    // partial draw_range reveal shows a body closed at its origin that grows
+    // along the path, with only the far (frontier) cap appearing last. ---
     const indicesPerRingPair = L * sections * 6;
     const ringPairCount = N - 1;
-    // End caps: revolution wall (L-1 bands) + a fan for any open end ring.
+    // End caps: revolution wall (L-1 bands) + a triangle fan (sections-2 tris)
+    // for any open end ring.
     const r0End = pr[0], r1End = pr[L - 1];
     const capBandsPerEnd = (L - 1) * sections * 6;
-    const cap0Fan = r0End > 1e-9 ? sections * 3 : 0;
-    const cap1Fan = r1End > 1e-9 ? sections * 3 : 0;
+    const cap0Fan = r0End > 1e-9 ? (sections - 2) * 3 : 0;
+    const cap1Fan = r1End > 1e-9 ? (sections - 2) * 3 : 0;
     const capIndexCount = 2 * capBandsPerEnd + cap0Fan + cap1Fan;
     const indices = new Uint32Array(ringPairCount * indicesPerRingPair + capIndexCount);
     let w = 0;
     const ringStart = (k, l) => (k * L + l) * sections;
-    // Side loft (station-major).
-    for (let k = 0; k < N - 1; k++) {
-        for (let l = 0; l < L; l++) {
-            const a0 = ringStart(k, l), b0 = ringStart(k + 1, l);
-            for (let s = 0; s < sections; s++) {
-                const s1 = (s + 1) % sections;
-                const a = a0 + s, an = a0 + s1, b = b0 + s, bn = b0 + s1;
-                indices[w++] = a; indices[w++] = b; indices[w++] = bn;
-                indices[w++] = a; indices[w++] = bn; indices[w++] = an;
-            }
-        }
-    }
-    // End-cap revolution walls + fans. Appended after the side faces so a
-    // partial draw_range grows the body before the far cap appears.
+    // Revolution wall closing the tool-body shell at one station (connects
+    // consecutive profile levels around the axis).
     const addCap = (k, flip) => {
         for (let l = 0; l < L - 1; l++) {
             const a0 = ringStart(k, l), b0 = ringStart(k, l + 1);
@@ -3982,8 +3972,8 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
         }
     };
     const addFan = (k, l, flip) => {
-        // Fan the open ring at level l to its centre (a fresh vertex appended
-        // to positions/colors is avoided by triangulating around vertex 0).
+        // Fan the open ring at level l to its centre, triangulating around
+        // vertex 0 (sections-2 triangles) so no extra centre vertex is needed.
         const base = ringStart(k, l);
         for (let s = 1; s < sections - 1; s++) {
             const a = base, b = base + s, c = base + s + 1;
@@ -3991,9 +3981,23 @@ function buildSweptToolGeometry(stationPos, axisArr, profileArr, sections, ringC
             else { indices[w++] = a; indices[w++] = c; indices[w++] = b; }
         }
     };
+    // Start cap first, so the origin end is closed from the first reveal frame.
     addCap(0, true);             // start cap faces inward (toward -path)
-    addCap(N - 1, false);        // end cap faces outward
     if (cap0Fan) addFan(0, 0, true);
+    // Side loft (station-major): per level l, connect station k ring to k+1.
+    for (let k = 0; k < N - 1; k++) {
+        for (let l = 0; l < L; l++) {
+            const a0 = ringStart(k, l), b0 = ringStart(k + 1, l);
+            for (let s = 0; s < sections; s++) {
+                const s1 = (s + 1) % sections;
+                const a = a0 + s, an = a0 + s1, b = b0 + s, bn = b0 + s1;
+                indices[w++] = a; indices[w++] = b; indices[w++] = bn;
+                indices[w++] = a; indices[w++] = bn; indices[w++] = an;
+            }
+        }
+    }
+    // End cap last (the frontier of the reveal).
+    addCap(N - 1, false);        // end cap faces outward
     if (cap1Fan) addFan(N - 1, L - 1, false);
 
     const geometry = new THREE.BufferGeometry();
@@ -8612,7 +8616,7 @@ export class ThreeJSViewer {
                                 // the material into vertexColors mode.
                                 /** @type {any} */
                                 const matOpts = {
-                                    size: data.size || 2.0,
+                                    size: data.size ?? 2.0,
                                     sizeAttenuation: data.sizeAttenuation !== false,
                                 };
                                 if (data.hasVertexColors) {
@@ -8624,7 +8628,7 @@ export class ThreeJSViewer {
                                     geometry.setAttribute('color', new THREE.Float32BufferAttribute(colorData, 3));
                                     matOpts.vertexColors = true;
                                 } else {
-                                    matOpts.color = data.color || 0xffffff;
+                                    matOpts.color = data.color ?? 0xffffff;
                                 }
                                 const material = new THREE.PointsMaterial(matOpts);
                                 const points = new THREE.Points(geometry, material);
@@ -9195,7 +9199,7 @@ export class ThreeJSViewer {
                                 );
                                 const opacity = data.opacity !== undefined ? data.opacity : 1;
                                 const material = new THREE.MeshStandardMaterial({
-                                    color: hasColors ? 0xffffff : (data.color || 0x9aa0a6),
+                                    color: hasColors ? 0xffffff : (data.color ?? 0x9aa0a6),
                                     metalness: data.metalness !== undefined ? data.metalness : 0.3,
                                     roughness: data.roughness !== undefined ? data.roughness : 0.6,
                                     opacity,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2780,10 +2780,13 @@ def test_binary_draw_ranges_channel_on_swept_tool_and_points(
     )
     anim.set_draw_range_data(["shank", "cloud"], ramp)
     viewer_client.load_animation(anim, autoplay=False)
+    loaded = False
     for _ in range(40):
         time.sleep(0.05)
         if viewer_page.evaluate("() => window.threejsViewer._animation != null"):
+            loaded = True
             break
+    assert loaded, "animation never loaded"
     # Seek to mid-animation; the binary channel applier must set both draw ranges.
     viewer_page.evaluate("() => window.threejsViewer._seekToTime(0.5)")
     got = None

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2750,3 +2750,88 @@ def test_clip_tool_has_refined_rotate_and_slide_gizmos(viewer_client, viewer_pag
         if off and not off["move"]:
             break
     assert off is not None and not off["rot"] and not off["move"]
+
+
+@pytest.mark.browser
+def test_binary_draw_ranges_channel_on_swept_tool_and_points(
+    viewer_client, viewer_page
+):
+    """The binary `draw_ranges` animation channel (set_draw_range_data) drives
+    draw range on a swept tool AND a point cloud. This is a DIFFERENT code path
+    (makeChannelApply.draw_ranges) from the `set_draw_range` message
+    (_setDrawRange); a regression in the channel applier would otherwise pass
+    every other test while breaking the example reveals."""
+    n = 30
+    t = np.linspace(0, 1, n)
+    positions = np.column_stack([t * 6 - 3, 0 * t, 0 * t]).astype(np.float32)
+    axes = np.tile([0, 0, 1.0], (n, 1)).astype(np.float32)
+    profile = np.array([[0, 0.4], [4.0, 0.4]], dtype=np.float32)
+    viewer_client.add_swept_tool("shank", positions, axes, profile)
+    pts = np.random.default_rng(0).random((400, 3)).astype(np.float32)
+    viewer_client.add_points("cloud", pts)
+    time.sleep(0.4)  # let the binary HTTP loads land
+
+    n_frames = 11
+    anim = Animation(loop=False)
+    anim.set_frame_times(np.linspace(0, 1.0, n_frames, dtype=np.float32))
+    # One channel covering both ids; values ramp 0 -> 1 so t=0.5 -> ~0.5.
+    ramp = np.tile(
+        np.linspace(0, 1, n_frames, dtype=np.float32).reshape(n_frames, 1), (1, 2)
+    )
+    anim.set_draw_range_data(["shank", "cloud"], ramp)
+    viewer_client.load_animation(anim, autoplay=False)
+    for _ in range(40):
+        time.sleep(0.05)
+        if viewer_page.evaluate("() => window.threejsViewer._animation != null"):
+            break
+    # Seek to mid-animation; the binary channel applier must set both draw ranges.
+    viewer_page.evaluate("() => window.threejsViewer._seekToTime(0.5)")
+    got = None
+    for _ in range(40):
+        time.sleep(0.05)
+        objs = viewer_client.query_scene()["objects"]
+        shank = objs.get("shank", {}).get("drawRange")
+        cloud = objs.get("cloud", {}).get("drawRange")
+        if shank is not None and cloud is not None:
+            got = (shank, cloud)
+            if abs(shank - 0.5) < 0.1 and abs(cloud - 0.5) < 0.1:
+                break
+    assert got is not None, "objects never appeared"
+    assert abs(got[0] - 0.5) < 0.1, (
+        f"swept tool draw range did not advance via channel: {got[0]}"
+    )
+    assert abs(got[1] - 0.5) < 0.1, (
+        f"point cloud draw range did not advance via channel: {got[1]}"
+    )
+
+
+@pytest.mark.browser
+def test_flat_black_color_is_honored_not_falsy_substituted(viewer_client, viewer_page):
+    """color=0x000000 (no vertex colors) must render black, not the default —
+    guards the `data.color ?? default` (vs `||`) falsy-zero fix on points and
+    the swept tool."""
+    viewer_client.add_points(
+        "blackpts", np.zeros((10, 3), dtype=np.float32), color=0x000000
+    )
+    n = 6
+    positions = np.column_stack(
+        [np.linspace(0, 3, n), np.zeros(n), np.zeros(n)]
+    ).astype(np.float32)
+    axes = np.tile([0, 0, 1.0], (n, 1)).astype(np.float32)
+    profile = np.array([[0, 0.3], [2.0, 0.3]], dtype=np.float32)
+    viewer_client.add_swept_tool("blacktool", positions, axes, profile, color=0x000000)
+    got = None
+    for _ in range(40):
+        time.sleep(0.05)
+        got = viewer_page.evaluate(
+            "() => {"
+            " const o = window.threejsViewer._objects;"
+            " const p = o.get('blackpts'), t = o.get('blacktool');"
+            " return p && t ? {pts: p.material.color.getHex(), tool: t.material.color.getHex()} : null;"
+            "}"
+        )
+        if got:
+            break
+    assert got is not None, "objects never landed"
+    assert got["pts"] == 0x000000, f"black point cloud rendered {got['pts']:#08x}"
+    assert got["tool"] == 0x000000, f"black swept tool rendered {got['tool']:#08x}"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -363,6 +363,15 @@ def test_add_points_rejects_color_length_mismatch(client):
     # (N, 3) RGB with the wrong row count too.
     with pytest.raises(ValueError, match="length 3"):
         client.add_points("pc", pts, colors=np.zeros((2, 3), dtype=np.float32))
+    # A 0-D scalar must raise a clean ValueError, not an IndexError on shape[0].
+    with pytest.raises(ValueError, match="length 3"):
+        client.add_points("pc", pts, colors=np.float32(0.5))
+
+
+def test_add_points_rejects_bad_positions_shape(client):
+    # 1D length not a multiple of 3 — must raise, not silently truncate via // 3.
+    with pytest.raises(ValueError):
+        client.add_points("pc", np.zeros(7, dtype=np.float32))
 
 
 def test_add_points_with_parent(client):
@@ -455,6 +464,15 @@ def test_add_swept_tool_validates(client):
         client.add_swept_tool("t", pos, axes, profile, sections=2)
     with pytest.raises(ValueError, match="length"):
         client.add_swept_tool("t", pos, axes[:2], profile)
+    # Heights must be non-decreasing (the docstring's contract).
+    with pytest.raises(ValueError, match="non-decreasing"):
+        client.add_swept_tool(
+            "t", pos, axes, np.array([[0, 0.5], [2, 0.4], [1, 0.3]], dtype=np.float32)
+        )
+    # Equal consecutive heights (a vertical step) must be allowed.
+    client.add_swept_tool(
+        "t", pos, axes, np.array([[0, 0.5], [1, 0.5], [1, 0.3]], dtype=np.float32)
+    )
 
 
 # === Toolpath.add_toolpath ===

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -354,6 +354,17 @@ def test_add_points_rejects_bad_color_shape(client):
         client.add_points("pc", pts, colors=rgba)
 
 
+def test_add_points_rejects_color_length_mismatch(client):
+    pts = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]], dtype=np.float32)
+    # 2 scalars for 3 points — would pack a misaligned color blob (NaN colors
+    # in the browser) without this guard.
+    with pytest.raises(ValueError, match="length 3"):
+        client.add_points("pc", pts, colors=np.array([0.0, 1.0], dtype=np.float32))
+    # (N, 3) RGB with the wrong row count too.
+    with pytest.raises(ValueError, match="length 3"):
+        client.add_points("pc", pts, colors=np.zeros((2, 3), dtype=np.float32))
+
+
 def test_add_points_with_parent(client):
     pts = np.array([[0, 0, 0], [1, 1, 1]], dtype=np.float32)
     client.add_points("pc", pts, parent="g")


### PR DESCRIPTION
The low-risk, mechanical follow-ups from the post-merge reviews of #64 (points) and #69 (swept tool). The riskier near-vertical frame fix is intentionally **not** here — it's a separate geometry PR (with before/after screenshots) since it carries regression risk and is within the issue's accepted "linear loft can pinch — fine for us" envelope.

## Fixes
- **Falsy-zero guards** (`?? ` instead of `||`): a flat black point cloud or swept tool (`color=0x000000`, no vertex colors) now renders black instead of the default gray/white; `add_points(size=0)` is honored instead of snapping to 2px.
- **`add_points` color-length validation**: raise when `len(colors) != n_points`, mirroring the existing `(N,3)` shape check — a mismatch previously packed a misaligned blob → `NaN` vertex colors in the browser with no error.
- **Swept-tool `buildSweptToolGeometry`**:
  - Emit the **start cap before the side loft** so the origin end is closed from the first `draw_range` frame (only the far/frontier cap appears last). Verified visually: at `draw_range=0.4` the origin is a closed ball nose, the frontier is the growing edge.
  - Fix the **end-cap fan over-allocation** → `(sections-2)*3`, so the index buffer has no trailing zero-index degenerate triangles and `totalIndexCount` is exact.

## Tests
- **Regression test for the binary `draw_ranges` animation channel** (`set_draw_range_data`) on a swept tool **and** a point cloud — `makeChannelApply.draw_ranges` is a *separate* path from the `set_draw_range` message and had silently drifted out of sync before (the bug that broke the example reveals). Seeks mid-animation and asserts both draw ranges advance.
- Browser test asserting flat black is honored on both primitives.
- Unit test for the colors-length-mismatch `ValueError`.

`tsc` clean, `viewer.html` regenerated (placeholder preserved), `ruff` clean, 57 unit + targeted browser tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)