### PR TITLE
Deflake browser tests under full-suite load (#95)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,17 +34,23 @@ def _free_port():
 
 @pytest.fixture()
 def viewer_client():
-    """Start a ViewerClient on a random port (does not wait for browser)."""
+    """Start a ViewerClient on a random port (does not wait for browser).
+
+    The HTTP blob sidecar binds port 0 (the OS hands out a genuinely free
+    port, no allocate-release-rebind window): under parallel/full-suite load
+    the old `_free_port()`-then-bind dance intermittently lost the race and
+    errored the whole test at setup with "Address already in use" (#95). The
+    blob URLs embed the actual bound port, so it does not need to be ws+1.
+    """
     port = _free_port()
     client = ViewerClient(port=port, open_browser=False)
 
-    # Start the server in the background without blocking for a browser connection
-    client._http_port = port + 1
     from http.server import HTTPServer
 
     from threejs_viewer.client import _BlobHandler
 
-    http_server = HTTPServer((client.host, client._http_port), _BlobHandler)
+    http_server = HTTPServer((client.host, 0), _BlobHandler)
+    client._http_port = http_server.server_address[1]
     http_server.blob_store = client._blob_store
     client._http_server = http_server
     threading.Thread(target=http_server.serve_forever, daemon=True).start()
@@ -61,13 +67,21 @@ if _has_playwright:
 
     @pytest.fixture()
     def viewer_page(viewer_client, page):
-        """Open the viewer in Playwright and wait for WebSocket connection."""
+        """Open the viewer in Playwright and wait for WebSocket connection.
+
+        goto gets a generous timeout plus one retry: under full-suite machine
+        load a file:// navigation occasionally exceeded the 30 s default and
+        errored unrelated tests at setup (#95).
+        """
         viewer_path = viewer_client.viewer_path.resolve()
         url = f"file://{viewer_path}?ws_port={viewer_client.port}"
-        page.goto(url)
+        try:
+            page.goto(url, timeout=90_000)
+        except Exception:
+            page.goto(url, timeout=90_000)
 
         # Wait for the browser to connect via WebSocket
-        connected = viewer_client._connected_event.wait(timeout=10)
-        assert connected, "Browser did not connect to WebSocket server within 10s"
+        connected = viewer_client._connected_event.wait(timeout=30)
+        assert connected, "Browser did not connect to WebSocket server within 30s"
 
         yield page

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,11 +73,13 @@ if _has_playwright:
         load a file:// navigation occasionally exceeded the 30 s default and
         errored unrelated tests at setup (#95).
         """
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
         viewer_path = viewer_client.viewer_path.resolve()
-        url = f"file://{viewer_path}?ws_port={viewer_client.port}"
+        url = f"{viewer_path.as_uri()}?ws_port={viewer_client.port}"
         try:
             page.goto(url, timeout=90_000)
-        except Exception:
+        except PlaywrightTimeoutError:
             page.goto(url, timeout=90_000)
 
         # Wait for the browser to connect via WebSocket

--- a/tests/test_parametric_tube.py
+++ b/tests/test_parametric_tube.py
@@ -491,26 +491,38 @@ def test_parametric_tube_frontier_restores_on_full(viewer_client, viewer_page):
     )
     _wait_for_object(viewer_page, "tube_restore")
 
-    # Morph ring 5 by setting draw_range to 0.5
-    viewer_client.set_draw_range("tube_restore", 0.5)
-    time.sleep(0.1)
-
-    # Now set to 1.0 — all rings should be at original positions
-    viewer_client.set_draw_range("tube_restore", 1.0)
-    time.sleep(0.1)
-
-    x_avg = viewer_page.evaluate(
-        """(id) => {
-            const obj = window.threejsViewer._objects.get(id);
-            const pos = obj.geometry.getAttribute('position').array;
-            const nCs = obj.userData.tubeNCs;
-            const ring5 = 5;
-            let sum = 0;
-            for (let j = 0; j < nCs; j++) sum += pos[(ring5 * nCs + j) * 3];
-            return sum / nCs;
-        }""",
-        "tube_restore",
+    ring5_x = (
+        "() => {"
+        " const obj = window.threejsViewer._objects.get('tube_restore');"
+        " const pos = obj.geometry.getAttribute('position').array;"
+        " const nCs = obj.userData.tubeNCs;"
+        " let sum = 0;"
+        " for (let j = 0; j < nCs; j++) sum += pos[(5 * nCs + j) * 3];"
+        " return sum / nCs;"
+        "}"
     )
+
+    # Morph ring 5 by setting draw_range to 0.5 — POLL until the morph has
+    # actually applied (fixed sleeps raced the WS delivery under full-suite
+    # load and read the ring mid-restore, #95).
+    viewer_client.set_draw_range("tube_restore", 0.5)
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if abs(viewer_page.evaluate(ring5_x) - 4.5) < 0.05:
+            break
+        time.sleep(0.02)
+    else:
+        pytest.fail("draw_range 0.5 never morphed ring 5 to x~4.5")
+
+    # Now set to 1.0 — all rings should return to original positions.
+    viewer_client.set_draw_range("tube_restore", 1.0)
+    x_avg = None
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        x_avg = viewer_page.evaluate(ring5_x)
+        if abs(x_avg - 5.0) < 0.05:
+            break
+        time.sleep(0.02)
     assert abs(x_avg - 5.0) < 0.05, (
         f"Expected restored ring 5 center X ~5.0, got {x_avg}"
     )


### PR DESCRIPTION
Closes #95.

All three one-off failures were timing races in test infrastructure, not product bugs:

| symptom | root cause | fix |
|---|---|---|
| `Address already in use` at fixture setup (also hit 3× in CI today) | `_free_port()` binds-reads-**releases**, then the HTTP sidecar binds `port+1` later — a textbook TOCTOU under parallel load | sidecar binds **port 0** directly; the OS hands out a genuinely free port with no window. Blob URLs embed the actual bound port, so it never needed to be `ws+1` |
| `Page.goto: Timeout 30000ms exceeded` at setup of unrelated tests | `file://` navigation under full-suite machine load | 90 s timeout + one retry; WS connect wait 10 s → 30 s |
| `Expected restored ring 5 center X ~5.0, got 4.5` | fixed `sleep(0.1)`s raced WS delivery — 4.5 is exactly the *half-morphed* frontier position, read mid-restore | both steps poll for their applied state (5 s deadline) instead of sleeping |

Verified: two consecutive full 388-test suite runs green locally (previously each full run produced a different failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)