### PR TITLE
Guard transport time readout against NaN + wrap timeline row

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -93,6 +93,19 @@
             display: flex;
             align-items: center;
             gap: 12px;
+            /* On narrow viewports the transport controls no longer fit one line: wrap
+               so the scrubber drops to its own second row instead of overflowing. The
+               timeline-container's flex-basis (below) forces the wrap once the row is
+               too tight. The toolbar ResizeObserver picks up the taller row and lifts
+               the viewport content accordingly. */
+            flex-wrap: wrap;
+        }
+        .threejs-viewer .timeline-row .tjsv-timeline-container {
+            /* min-width stops flex-shrink from collapsing the scrubber to nothing on a
+               tight row — once it can't hold its min width beside the other controls it
+               wraps to its own line instead. flex-basis keeps it wide when there's room. */
+            flex: 1 1 220px;
+            min-width: 200px;
         }
         .threejs-viewer .transport-buttons {
             display: flex;
@@ -9197,7 +9210,7 @@ class ThreeJSViewer {
         // updates (reflow on resize, content changes) flow through the
         // observer.
         this._refreshAnimLift();
-        this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
+        this._totalTimeEl.textContent = this._formatTime(this._animation.duration);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
         this._btnLoop.classList.toggle('active', this._animationLoop);
@@ -9620,12 +9633,24 @@ class ThreeJSViewer {
         return { index: lo, t: dt > 0 ? (time - frames[lo].time) / dt : 0 };
     }
 
+    /**
+     * Format a seconds value for the transport readout, guarding against
+     * non-finite inputs. A NaN/Inf animation time (e.g. an empty or malformed
+     * keyframe stream) must never reach the DOM as "NaN" — it renders as the
+     * numeric zero fallback instead, matching the 2-dp format.
+     * @param {number} seconds
+     * @returns {string}
+     */
+    _formatTime(seconds) {
+        return (Number.isFinite(seconds) ? seconds : 0).toFixed(2);
+    }
+
     _updateAnimationUI() {
         if (!this._animation) return;
         const { index: frameIndex } = this._getFrameAtTime(this._animationTime);
         const progress = this._animation.duration > 0 ? (this._animationTime / this._animation.duration) * 100 : 0;
-        this._timelineProgressEl.style.width = `${progress}%`;
-        this._currentTimeEl.textContent = this._animationTime.toFixed(2);
+        this._timelineProgressEl.style.width = `${Number.isFinite(progress) ? progress : 0}%`;
+        this._currentTimeEl.textContent = this._formatTime(this._animationTime);
         this._currentFrameEl.textContent = frameIndex + 1;
         this._btnPlay.textContent = this._animationPlaying ? '\u23F8' : '\u25B6';
     }

--- a/src/threejs_viewer/viewer/viewer.css
+++ b/src/threejs_viewer/viewer/viewer.css
@@ -82,6 +82,19 @@
     display: flex;
     align-items: center;
     gap: 12px;
+    /* On narrow viewports the transport controls no longer fit one line: wrap
+       so the scrubber drops to its own second row instead of overflowing. The
+       timeline-container's flex-basis (below) forces the wrap once the row is
+       too tight. The toolbar ResizeObserver picks up the taller row and lifts
+       the viewport content accordingly. */
+    flex-wrap: wrap;
+}
+.threejs-viewer .timeline-row .tjsv-timeline-container {
+    /* min-width stops flex-shrink from collapsing the scrubber to nothing on a
+       tight row — once it can't hold its min width beside the other controls it
+       wraps to its own line instead. flex-basis keeps it wide when there's room. */
+    flex: 1 1 220px;
+    min-width: 200px;
 }
 .threejs-viewer .transport-buttons {
     display: flex;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -8088,7 +8088,7 @@ export class ThreeJSViewer {
         // updates (reflow on resize, content changes) flow through the
         // observer.
         this._refreshAnimLift();
-        this._totalTimeEl.textContent = this._animation.duration.toFixed(2);
+        this._totalTimeEl.textContent = this._formatTime(this._animation.duration);
         this._totalFramesEl.textContent = this._animation.frames.length;
         this._animationLoop = this._animation.loop;
         this._btnLoop.classList.toggle('active', this._animationLoop);
@@ -8511,12 +8511,24 @@ export class ThreeJSViewer {
         return { index: lo, t: dt > 0 ? (time - frames[lo].time) / dt : 0 };
     }
 
+    /**
+     * Format a seconds value for the transport readout, guarding against
+     * non-finite inputs. A NaN/Inf animation time (e.g. an empty or malformed
+     * keyframe stream) must never reach the DOM as "NaN" — it renders as the
+     * numeric zero fallback instead, matching the 2-dp format.
+     * @param {number} seconds
+     * @returns {string}
+     */
+    _formatTime(seconds) {
+        return (Number.isFinite(seconds) ? seconds : 0).toFixed(2);
+    }
+
     _updateAnimationUI() {
         if (!this._animation) return;
         const { index: frameIndex } = this._getFrameAtTime(this._animationTime);
         const progress = this._animation.duration > 0 ? (this._animationTime / this._animation.duration) * 100 : 0;
-        this._timelineProgressEl.style.width = `${progress}%`;
-        this._currentTimeEl.textContent = this._animationTime.toFixed(2);
+        this._timelineProgressEl.style.width = `${Number.isFinite(progress) ? progress : 0}%`;
+        this._currentTimeEl.textContent = this._formatTime(this._animationTime);
         this._currentFrameEl.textContent = frameIndex + 1;
         this._btnPlay.textContent = this._animationPlaying ? '\u23F8' : '\u25B6';
     }


### PR DESCRIPTION
## Problem
The shared animation transport template (`.timeline-row` / `.tjsv-current-time` in `viewer/viewer.js`) has two lane-agnostic UI bugs, surfaced by ribweaver PR #393 (which worked around them from `sim.html`):

1. When the animation time is non-finite (empty or malformed keyframe stream), the current-time readout rendered literally as `NaN` — e.g. `NaNs / 7463.41s`.
2. On narrow viewports the transport controls overflowed the single `.timeline-row` instead of wrapping.

Both live in this shared template, so every embedding lane (panel / boat / mill / sim) is affected. Fixing upstream lets the per-lane workaround retire.

## Fix
- **`viewer/viewer.js`** — new `_formatTime(seconds)` clamps a non-finite value to `0` before `.toFixed(2)`. Used for both the current-time and total-time readouts. The timeline progress width is guarded the same way.
- **`viewer/viewer.css`** — `.timeline-row` gets `flex-wrap: wrap`; `.tjsv-timeline-container` gets `min-width: 200px` (plus `flex: 1 1 220px`) so the scrubber drops to its own second row when the row is too tight, rather than shrinking to nothing or overflowing.
- **`viewer.html`** — regenerated from source via `viewer/build.py` (the served, self-contained bundle).

## Verification (Chromium, real DOM)
Driven against the built `viewer.html` with a fake animation:

| case | result |
|---|---|
| NaN animation time (before) | `NaNs / 7463.41s` (the bug) |
| NaN animation time (after) | `0.00s / 7463.41s` |
| finite time `12.3456` | `12.35` (unchanged) |
| horizontal overflow @ 360/480/640/1400px | `0` at every width |
| scrubber wraps below transport buttons @ 360px | yes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p6cUy1WS5SrYGp72Rx7wi