### PR TITLE
Expose window.tjsv debug handle (THREE/scene/camera/renderer)

### DIFF
--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -6755,10 +6755,11 @@ export class ThreeJSViewer {
         this._initThreeJS();
 
         // Dev-debug convenience (ribweaver#495): last-constructed viewer's
-        // scene/camera/renderer, for console lighting/material tweaks
-        // alongside window.THREE. Not a public API — internals may change.
+        // THREE/scene/camera/renderer, for console lighting/material tweaks.
+        // Not a public API — internals may change.
         if (typeof window !== 'undefined') {
-            /** @type {any} */ (window).__threeJSViewerDebug = {
+            /** @type {any} */ (window).tjsv = {
+                THREE,
                 viewer: this,
                 scene: this._scene,
                 camera: this._camera,

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -12022,6 +12022,12 @@ export class ThreeJSViewer {
 
     destroy() {
         this._destroyed = true;
+        // Drop the dev-debug handle if it still points at this instance, so
+        // destroy() doesn't leave window.tjsv pinning a disposed viewer's
+        // scene/renderer past GC.
+        if (typeof window !== 'undefined' && /** @type {any} */ (window).tjsv?.viewer === this) {
+            /** @type {any} */ (window).tjsv = undefined;
+        }
         cancelAnimationFrame(this._animationFrameId);
         if (this._ws) {
             this._ws.onclose = null;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -19,15 +19,6 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 
-// Dev-debug convenience (ribweaver#495): expose the THREE namespace on
-// `window` so a developer can tweak lighting/materials from the browser
-// console (e.g. `new THREE.DirectionalLight(...)`) without a build step.
-// Matches the precedent of other debug-only globals in this file (see
-// `window.__tubeDrawCapOverride`).
-if (typeof window !== 'undefined') {
-    /** @type {any} */ (window).THREE = THREE;
-}
-
 const VIEWER_VERSION = '0.0.0-dev';
 
 const ORTHO_FRUSTUM = 10;

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -19,6 +19,15 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 
+// Dev-debug convenience (ribweaver#495): expose the THREE namespace on
+// `window` so a developer can tweak lighting/materials from the browser
+// console (e.g. `new THREE.DirectionalLight(...)`) without a build step.
+// Matches the precedent of other debug-only globals in this file (see
+// `window.__tubeDrawCapOverride`).
+if (typeof window !== 'undefined') {
+    /** @type {any} */ (window).THREE = THREE;
+}
+
 const VIEWER_VERSION = '0.0.0-dev';
 
 const ORTHO_FRUSTUM = 10;
@@ -6744,6 +6753,18 @@ export class ThreeJSViewer {
 
         // Init Three.js
         this._initThreeJS();
+
+        // Dev-debug convenience (ribweaver#495): last-constructed viewer's
+        // scene/camera/renderer, for console lighting/material tweaks
+        // alongside window.THREE. Not a public API — internals may change.
+        if (typeof window !== 'undefined') {
+            /** @type {any} */ (window).__threeJSViewerDebug = {
+                viewer: this,
+                scene: this._scene,
+                camera: this._camera,
+                renderer: this._renderer,
+            };
+        }
 
         // Init clipping
         this._initClipping();


### PR DESCRIPTION
## Summary
- `window.tjsv = {THREE, viewer, scene, camera, renderer}` set after `_initThreeJS()` in the constructor — last-constructed viewer wins
- `destroy()` clears `window.tjsv` if it still points at the destroying instance (no GC pin)
- Debug-only convenience, not a public API; matches the existing `window.__tubeDrawCapOverride` precedent in this file

Closes #124. Closes CEAD-group/ribweaver#495.

## Test plan
- [x] `npx tsc --noEmit -p jsconfig.json` clean
- [x] `uv run pytest` — 421 passed
- [x] Playwright smoke against a live ribweaver `/panel` page (editable install): `window.THREE` is undefined, `window.tjsv.THREE.Scene` is a function, `window.tjsv.scene instanceof window.tjsv.THREE.Scene` is true