### PR TITLE
Regenerate viewer.html (stale after #125)

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -7891,6 +7891,19 @@ class ThreeJSViewer {
         // Init Three.js
         this._initThreeJS();
 
+        // Dev-debug convenience (ribweaver#495): last-constructed viewer's
+        // THREE/scene/camera/renderer, for console lighting/material tweaks.
+        // Not a public API — internals may change.
+        if (typeof window !== 'undefined') {
+            /** @type {any} */ (window).tjsv = {
+                THREE,
+                viewer: this,
+                scene: this._scene,
+                camera: this._camera,
+                renderer: this._renderer,
+            };
+        }
+
         // Init clipping
         this._initClipping();
 
@@ -13146,6 +13159,12 @@ class ThreeJSViewer {
 
     destroy() {
         this._destroyed = true;
+        // Drop the dev-debug handle if it still points at this instance, so
+        // destroy() doesn't leave window.tjsv pinning a disposed viewer's
+        // scene/renderer past GC.
+        if (typeof window !== 'undefined' && /** @type {any} */ (window).tjsv?.viewer === this) {
+            /** @type {any} */ (window).tjsv = undefined;
+        }
         cancelAnimationFrame(this._animationFrameId);
         if (this._ws) {
             this._ws.onclose = null;


### PR DESCRIPTION
PR #125 changed `viewer.js` (the `window.tjsv` debug handle + `destroy()` cleanup) without regenerating `viewer.html`, so the "Verify viewer.html is up to date" CI step fails on main. This is the mechanical `build.py` regen — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)