### PR TITLE
Derive the package version from the git tag (hatch-vcs)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -131,6 +131,10 @@ jobs:
           export SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION
           uv pip install build
           uv run python -m build
+          # PRETEND_VERSION dictates the version rather than deriving it, so a
+          # wrong $VERSION would publish silently. Assert what we actually built.
+          test -f "dist/threejs_viewer-$VERSION-py3-none-any.whl" \
+            || (echo "ERROR: built wheel is not version $VERSION" && ls dist && exit 1)
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -119,7 +119,12 @@ jobs:
           echo "Setting viewer version to $VERSION"
           # The Python package version comes from the tag via hatch-vcs; only
           # the JS bundle still carries a placeholder to substitute.
-          sed -i "s/0\.0\.0-dev/$VERSION/g" src/threejs_viewer/viewer/viewer.js
+          # Only the VIEWER_VERSION assignment — a global replace would also
+          # rewrite the literal where comments discuss the placeholder.
+          sed -i "s/^const VIEWER_VERSION = '0\.0\.0-dev';$/const VIEWER_VERSION = '$VERSION';/" \
+            src/threejs_viewer/viewer/viewer.js
+          grep -q "const VIEWER_VERSION = '$VERSION';" src/threejs_viewer/viewer/viewer.js \
+            || (echo "ERROR: VIEWER_VERSION was not stamped" && exit 1)
           uv run python src/threejs_viewer/viewer/build.py
 
       - name: Build package

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version from git tags
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -64,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version from git tags
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -98,24 +104,31 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version from git tags
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.11"
 
-      - name: Update version from tag
+      - name: Stamp viewer version from tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Setting version to $VERSION"
-          sed -i "s/0\.0\.0-dev/$VERSION/g" \
-            pyproject.toml \
-            src/threejs_viewer/__init__.py \
-            src/threejs_viewer/viewer/viewer.js
+          echo "Setting viewer version to $VERSION"
+          # The Python package version comes from the tag via hatch-vcs; only
+          # the JS bundle still carries a placeholder to substitute.
+          sed -i "s/0\.0\.0-dev/$VERSION/g" src/threejs_viewer/viewer/viewer.js
           uv run python src/threejs_viewer/viewer/build.py
 
       - name: Build package
         run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          # The sed above leaves the tree dirty, which would otherwise make
+          # hatch-vcs append a +d<date> local segment that PyPI rejects. Pin
+          # the version to the tag instead.
+          export SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION
           uv pip install build
           uv run python -m build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,16 @@ uv run python examples/04_flying_teapots.py
 
 ## Versioning
 
-Source files use `0.0.0-dev` as a placeholder version. CI replaces it before build/publish:
+**The Python package version comes from the git tag** (`hatch-vcs`, issue #183): `pyproject.toml` declares `dynamic = ["version"]` with `[tool.hatch.version] source = "vcs"`, so a tagged build is `0.0.51` and an untagged checkout reports e.g. `0.0.51.dev3+g<sha>` — an editable install finally has a meaningful `importlib.metadata.version("threejs-viewer")` instead of the old `0.0.0.dev0`, which downstream floors (`threejs-viewer>=0.0.26`) could never satisfy. `__init__.__version__` reads that installed metadata, falling back to `0.0.0.dev0` for an uninstalled source tree. Anything that checks out this repo to build it needs the tags: `actions/checkout` with `fetch-depth: 0`.
+
+**The JS bundle still carries a placeholder.** `viewer.html` is generated and committed, so it cannot read git at import time — `src/threejs_viewer/viewer/viewer.js` keeps `VIEWER_VERSION = '0.0.0-dev'` and CI substitutes it at tag time before rebuilding:
 ```bash
-sed -i "s/0\.0\.0-dev/$VERSION/g" pyproject.toml src/threejs_viewer/__init__.py src/threejs_viewer/viewer/viewer.js
+sed -i "s/0\.0\.0-dev/$VERSION/g" src/threejs_viewer/viewer/viewer.js
 uv run python src/threejs_viewer/viewer/build.py  # regenerate viewer.html with substituted version
 ```
-The placeholder appears in three files: `pyproject.toml`, `src/threejs_viewer/__init__.py`, `src/threejs_viewer/viewer/viewer.js`. The build step propagates the version into `viewer.html`. Never commit a real version number — always keep `0.0.0-dev`.
+Never commit a real version number into `viewer.js` — always keep `0.0.0-dev`. The publish step also exports `SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION`, because that `sed` leaves the working tree dirty and hatch-vcs would otherwise append a `+d<date>` local segment that PyPI rejects (the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_<NAME>` form does **not** work here — hatch-vcs does not pass the dist name through to setuptools_scm).
+
+**Handshake consequence**: in a dev checkout the two sides now legitimately disagree (`0.0.51.dev3+g…` vs `0.0.0-dev`), so the `hello` version-mismatch warning is skipped whenever *either* side looks like a dev build — `_is_dev_version` in `client.py` and `isDevVersion` in `viewer.js`, both matching `dev`/`+`/`unknown`. Two released versions that differ still warn exactly as before.
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,10 @@ uv run python examples/04_flying_teapots.py
 
 **The JS bundle still carries a placeholder.** `viewer.html` is generated and committed, so it cannot read git at import time — `src/threejs_viewer/viewer/viewer.js` keeps `VIEWER_VERSION = '0.0.0-dev'` and CI substitutes it at tag time before rebuilding:
 ```bash
-sed -i "s/0\.0\.0-dev/$VERSION/g" src/threejs_viewer/viewer/viewer.js
+# Only the assignment — a global replace would also rewrite the literal in
+# comments that discuss the placeholder (`isDevVersion`'s doc block).
+sed -i "s/^const VIEWER_VERSION = '0\.0\.0-dev';$/const VIEWER_VERSION = '$VERSION';/" \
+  src/threejs_viewer/viewer/viewer.js
 uv run python src/threejs_viewer/viewer/build.py  # regenerate viewer.html with substituted version
 ```
 Never commit a real version number into `viewer.js` — always keep `0.0.0-dev`. The publish step also exports `SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION`, because that `sed` leaves the working tree dirty and hatch-vcs would otherwise append a `+d<date>` local segment that PyPI rejects (the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_<NAME>` form does **not** work here — hatch-vcs does not pass the dist name through to setuptools_scm).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "threejs-viewer"
-version = "0.0.0-dev"
+dynamic = ["version"]
 description = "Lightweight Three.js viewer controlled from Python via WebSocket"
 readme = "README.md"
 license = "MIT"
@@ -33,8 +33,13 @@ Repository = "https://github.com/thijsdamsma/threejs-viewer"
 threejs-viewer = "threejs_viewer.__main__:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# Version comes from the git tag (e.g. v0.0.50 -> 0.0.50); an untagged dev
+# checkout reports 0.0.50.dev<N>+g<sha>.
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/threejs_viewer"]

--- a/src/threejs_viewer/__init__.py
+++ b/src/threejs_viewer/__init__.py
@@ -6,6 +6,8 @@ Three.js viewer connects to. Designed for robotics visualization,
 scientific computing, and interactive 3D exploration.
 """
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
 from .animation import (
     Animation,
     AnimationChannel,
@@ -29,4 +31,7 @@ __all__ = [
     "Toolpath",
 ]
 
-__version__ = "0.0.0-dev"
+try:
+    __version__ = _pkg_version("threejs-viewer")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0.dev0"

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -45,6 +45,23 @@ _ALLOWED_VIEWS = frozenset(
 )
 
 
+def _is_dev_version(version: str) -> bool:
+    """Is this a development build rather than a released version?
+
+    The bundled ``viewer.html`` carries the ``0.0.0-dev`` placeholder that CI
+    substitutes at tag time, while the Python package derives its version from
+    the git tag (``0.0.51.dev3+g<sha>`` in a checkout). Those never match, so
+    the handshake mismatch warning only means something between two *released*
+    versions.
+    """
+    return (
+        not isinstance(version, str)
+        or "dev" in version
+        or "+" in version
+        or version == "unknown"
+    )
+
+
 def _validate_finite(name: str, value: Optional[float]) -> Optional[float]:
     """Reject NaN/Inf so they never leak into the query string."""
     if value is None:
@@ -592,7 +609,9 @@ class ViewerClient:
         viewer_version = data.get("viewer_version", "unknown")
         logger = logging.getLogger(__name__)
         logger.info("Viewer v%s connected", viewer_version)
-        if viewer_version != __version__:
+        if viewer_version != __version__ and not (
+            _is_dev_version(viewer_version) or _is_dev_version(__version__)
+        ):
             print(
                 f"WARNING: Version mismatch — client v{__version__}, "
                 f"viewer v{viewer_version}. "

--- a/src/threejs_viewer/client.py
+++ b/src/threejs_viewer/client.py
@@ -45,7 +45,7 @@ _ALLOWED_VIEWS = frozenset(
 )
 
 
-def _is_dev_version(version: str) -> bool:
+def _is_dev_version(version: object) -> bool:
     """Is this a development build rather than a released version?
 
     The bundled ``viewer.html`` carries the ``0.0.0-dev`` placeholder that CI

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1263,6 +1263,21 @@ import { SMAAPass } from 'three/addons/postprocessing/SMAAPass.js';
 
 const VIEWER_VERSION = '0.0.0-dev';
 
+/**
+ * Is this a development build rather than a released version?
+ *
+ * The bundled viewer carries the `0.0.0-dev` placeholder that CI substitutes at
+ * tag time, while the Python side derives its version from the git tag
+ * (`0.0.51.dev3+g<sha>` in a checkout). Those never match, so the handshake's
+ * mismatch warning is only meaningful between two *released* versions.
+ *
+ * @param {string} v
+ * @returns {boolean}
+ */
+function isDevVersion(v) {
+    return typeof v !== 'string' || v.includes('dev') || v.includes('+') || v === 'unknown';
+}
+
 const ORTHO_FRUSTUM = 10;
 
 // Scene clear / background colour. Used both as scene.background (direct render
@@ -12209,7 +12224,8 @@ class ThreeJSViewer {
         switch (data.type) {
             case 'hello':
                 console.log(`Python client v${data.client_version}`);
-                if (data.client_version !== VIEWER_VERSION) {
+                if (data.client_version !== VIEWER_VERSION
+                    && !isDevVersion(VIEWER_VERSION) && !isDevVersion(data.client_version)) {
                     console.warn(
                         `Version mismatch: viewer v${VIEWER_VERSION}, client v${data.client_version}. ` +
                         `Close this tab and re-open viewer.html to pick up the latest version.`

--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -1271,7 +1271,7 @@ const VIEWER_VERSION = '0.0.0-dev';
  * (`0.0.51.dev3+g<sha>` in a checkout). Those never match, so the handshake's
  * mismatch warning is only meaningful between two *released* versions.
  *
- * @param {string} v
+ * @param {unknown} v Version string off the wire; may be anything.
  * @returns {boolean}
  */
 function isDevVersion(v) {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -31,7 +31,7 @@ const VIEWER_VERSION = '0.0.0-dev';
  * (`0.0.51.dev3+g<sha>` in a checkout). Those never match, so the handshake's
  * mismatch warning is only meaningful between two *released* versions.
  *
- * @param {string} v
+ * @param {unknown} v Version string off the wire; may be anything.
  * @returns {boolean}
  */
 function isDevVersion(v) {

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -23,6 +23,21 @@ import { SMAAPass } from 'three/addons/postprocessing/SMAAPass.js';
 
 const VIEWER_VERSION = '0.0.0-dev';
 
+/**
+ * Is this a development build rather than a released version?
+ *
+ * The bundled viewer carries the `0.0.0-dev` placeholder that CI substitutes at
+ * tag time, while the Python side derives its version from the git tag
+ * (`0.0.51.dev3+g<sha>` in a checkout). Those never match, so the handshake's
+ * mismatch warning is only meaningful between two *released* versions.
+ *
+ * @param {string} v
+ * @returns {boolean}
+ */
+function isDevVersion(v) {
+    return typeof v !== 'string' || v.includes('dev') || v.includes('+') || v === 'unknown';
+}
+
 const ORTHO_FRUSTUM = 10;
 
 // Scene clear / background colour. Used both as scene.background (direct render
@@ -10969,7 +10984,8 @@ export class ThreeJSViewer {
         switch (data.type) {
             case 'hello':
                 console.log(`Python client v${data.client_version}`);
-                if (data.client_version !== VIEWER_VERSION) {
+                if (data.client_version !== VIEWER_VERSION
+                    && !isDevVersion(VIEWER_VERSION) && !isDevVersion(data.client_version)) {
                     console.warn(
                         `Version mismatch: viewer v${VIEWER_VERSION}, client v${data.client_version}. ` +
                         `Close this tab and re-open viewer.html to pick up the latest version.`

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -374,3 +374,37 @@ def test_load_animation_rejects_bad_initial_time(bad_time):
     client = ViewerClient()
     with pytest.raises(ValueError, match="initial_time must be"):
         client.load_animation(_mini_animation(), initial_time=bad_time)
+
+
+class TestVersion:
+    """Version derivation (issue #183: hatch-vcs replaces the 0.0.0-dev placeholder)."""
+
+    def test_version_is_pep440_and_not_the_old_placeholder(self):
+        import threejs_viewer
+
+        version = threejs_viewer.__version__
+        assert isinstance(version, str) and version
+        # The whole point of #183: an installed checkout no longer reports the
+        # unsatisfiable 0.0.0 floor.
+        assert not version.startswith("0.0.0")
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "0.0.0-dev",
+            "0.0.0.dev0",
+            "0.0.51.dev3+ge8da667",
+            "0.0.51+ge8da667",
+            "unknown",
+        ],
+    )
+    def test_dev_versions_suppress_mismatch_warning(self, version):
+        from threejs_viewer.client import _is_dev_version
+
+        assert _is_dev_version(version)
+
+    @pytest.mark.parametrize("version", ["0.0.50", "1.2.3", "0.0.51a1"])
+    def test_released_versions_still_compared(self, version):
+        from threejs_viewer.client import _is_dev_version
+
+        assert not _is_dev_version(version)

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,6 @@ wheels = [
 
 [[package]]
 name = "threejs-viewer"
-version = "0.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Closes #183.

## What

- `pyproject.toml`: `dynamic = ["version"]` + `[tool.hatch.version] source = "vcs"` (build requires `hatch-vcs`). A tagged build is `0.0.51`; this checkout reports `0.0.51.dev0+ge8da667f9`.
- `__init__.__version__` reads `importlib.metadata`, falling back to `0.0.0.dev0` only for an uninstalled source tree.
- `uv.lock` now simply omits the root version (no per-commit churn).
- CI: every `actions/checkout` gets `fetch-depth: 0` (hatch-vcs needs tags); the release sed no longer touches `pyproject.toml`/`__init__.py`.

## The two wrinkles

1. **`viewer.js` keeps the `0.0.0-dev` placeholder.** `viewer.html` is generated and committed, so it cannot read git — CI still substitutes it at tag time. That means client and viewer *legitimately* disagree in a dev checkout, which would have fired the `hello` mismatch warning on every run. Both sides now skip the warning when either version looks like a dev build (`_is_dev_version` / `isDevVersion`, matching `dev`/`+`/`unknown`); two released versions that differ still warn exactly as before.
2. **The release sed dirties the tree**, so hatch-vcs would append a `+d<date>` local segment that PyPI rejects. The build step exports `SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION`. Note the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_<NAME>` form does *not* work — hatch-vcs does not pass the dist name to setuptools_scm (verified by building both ways).

## Verified

- `uv build --wheel` with the pretend version → `threejs_viewer-0.0.51-py3-none-any.whl`; without it → `…0.0.51.dev0+ge8da667f9…`.
- `uv sync`, `ruff check/format`, `tsc --noEmit`, `pytest -m "not browser"` (339 passed + 4 new version tests). Browser tests skip locally (no playwright group installed); CI covers them.

Nothing about the runtime or wire protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoVmF37jo29rBEbqNv8V81