### PR TITLE
Drop the dead userData.isBillboard flag

### DIFF
--- a/src/threejs_viewer/viewer.html
+++ b/src/threejs_viewer/viewer.html
@@ -3205,6 +3205,11 @@ function applyBillboard(obj, camera) {
 
 /**
  * Build the plane mesh for an `add_billboard` message.
+ *
+ * Nothing marks the mesh as a billboard here: `add_billboard` is just a plane
+ * plus `set_billboard`, and the flag that matters (`__isBillboard`, which gates
+ * base capture in every transform writer) is set by `_enableBillboard` for any
+ * object that carries the property.
  * @param {any} data
  * @param {THREE.Material} material
  * @returns {THREE.Mesh}
@@ -3212,9 +3217,7 @@ function applyBillboard(obj, camera) {
 function buildBillboardMesh(data, material) {
     const width = data.width > 0 ? data.width : 1;
     const height = data.height > 0 ? data.height : 1;
-    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
-    mesh.userData.isBillboard = true;
-    return mesh;
+    return new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
 }
 
 // Chamfered rectangle cross-section: 45° chamfers on all corners, depth =

--- a/src/threejs_viewer/viewer/viewer.js
+++ b/src/threejs_viewer/viewer/viewer.js
@@ -1965,6 +1965,11 @@ function applyBillboard(obj, camera) {
 
 /**
  * Build the plane mesh for an `add_billboard` message.
+ *
+ * Nothing marks the mesh as a billboard here: `add_billboard` is just a plane
+ * plus `set_billboard`, and the flag that matters (`__isBillboard`, which gates
+ * base capture in every transform writer) is set by `_enableBillboard` for any
+ * object that carries the property.
  * @param {any} data
  * @param {THREE.Material} material
  * @returns {THREE.Mesh}
@@ -1972,9 +1977,7 @@ function applyBillboard(obj, camera) {
 function buildBillboardMesh(data, material) {
     const width = data.width > 0 ? data.width : 1;
     const height = data.height > 0 ? data.height : 1;
-    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
-    mesh.userData.isBillboard = true;
-    return mesh;
+    return new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
 }
 
 // Chamfered rectangle cross-section: 45° chamfers on all corners, depth =


### PR DESCRIPTION
Spotted while answering "do we now have two billboard implementations?" — the answer is no, but the question landed next to a real trap.

`buildBillboardMesh` set `userData.isBillboard = true` (#185). It is **written once and read nowhere**, and it sits one underscore-pair away from `__isBillboard`, which is load-bearing: that flag gates `captureBillboardBase` in every transform writer. Testing the look-alike would compile, run, and leave base capture silently never firing — the composed pose would then be read back as the object's own rotation, which is exactly the drift failure `test_billboard_aim_does_not_drift_browser` exists to catch.

So: removed, with a comment on `buildBillboardMesh` explaining why the plane needs no mark of its own (`add_billboard` is a plane plus `set_billboard`; `_enableBillboard` sets `__isBillboard` for any object carrying the property).

For the record, there is exactly one orientation implementation:

- `applyBillboard` is the only place a billboard pose is computed, called from `_enableBillboard` (initial placement) and `_updateBillboards` (per frame).
- `add_billboard` and `set_billboard` both funnel into `_enableBillboard`.
- Python shares `_billboard_option_payload` between `add_billboard` and `set_billboard`.

`tsc --noEmit` clean, 12 billboard browser tests pass, `viewer.html` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoVmF37jo29rBEbqNv8V81